### PR TITLE
Fix of NCLOB incompatiblity with JDBC 11gR2

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/util/TypeNormaliserFactory.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/TypeNormaliserFactory.java
@@ -5,34 +5,29 @@ import java.util.Map;
 
 @SuppressWarnings("unchecked")
 public class TypeNormaliserFactory {
-    //private static Map<Class, TypeNormaliser> normalisers = new HashMap<Class, TypeNormaliser>();
-    private static Map<String, TypeNormaliser> normalisers = new HashMap<String, TypeNormaliser>();
+    private static Map<Class, TypeNormaliser> normalisers = new HashMap<Class, TypeNormaliser>();
 
     public static void setNormaliser(Class targetClass, TypeNormaliser normaliser) {
-        normalisers.put(targetClass.getCanonicalName(), normaliser);
-    }
-
-    public static void setNormaliser(String targetClassName, TypeNormaliser normaliser) {
-        normalisers.put(targetClassName, normaliser);
+        normalisers.put(targetClass, normaliser);
     }
 
     public static TypeNormaliser getNormaliser(Class targetClass) {
-        TypeNormaliser normaliser = normalisers.get(targetClass.getCanonicalName());
+        TypeNormaliser normaliser = normalisers.get(targetClass);
 
-        /*
         if (normaliser == null) {
             Class bestCandidate = targetClass;
             for (Class c: normalisers.keySet()) {
-                if (bestCandidate.isAssignableFrom(c)) {
+                if (c.isAssignableFrom(bestCandidate)) {
+                    // c is parent
                     bestCandidate = c;
                 }
             }
 
             if (bestCandidate != targetClass) {
                 normaliser = normalisers.get(bestCandidate);
+                normalisers.put(targetClass, normaliser);
             }
         }
-        */
 
         return normaliser;
     }

--- a/dbfit-java/oracle/src/main/java/dbfit/environment/OracleEnvironment.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/environment/OracleEnvironment.java
@@ -271,8 +271,6 @@ public class OracleEnvironment extends AbstractDbEnvironment {
                 new OracleDateNormaliser());
         TypeNormaliserFactory.setNormaliser(oracle.sql.CLOB.class,
                 new OracleClobNormaliser());
-        TypeNormaliserFactory.setNormaliser("oracle.sql.NCLOB",
-                new OracleClobNormaliser());
         TypeNormaliserFactory.setNormaliser(java.sql.Date.class,
                 new SqlDateNormaliser());
         try {


### PR DESCRIPTION
Not ready yet for merging but just an example for quick and dirty fix which workarounds the NCLOB incompatibility with JDBC 11gR2.

(Targets issue #53 and #28)
