### PR TITLE
Fixed typo which breaks MySql FitnesseSuite tests

### DIFF
--- a/dbfit-java/mysql/src/test/java/dbfit/environment/FlowModeTest.java
+++ b/dbfit-java/mysql/src/test/java/dbfit/environment/FlowModeTest.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 import static fitnesse.junit.FitNesseSuite.*;
 
 @RunWith(FitNesseSuite.class)
-@Name("DbFit.AcceptanceTests.JavaTests.MysqlTests.FlowMode")
+@Name("DbFit.AcceptanceTests.JavaTests.MySqlTests.FlowMode")
 @FitnesseDir("../..")
 @OutputDir(systemProperty = "java.io.tmpdir", pathExtension = "fitnesse")
 @Port(1234)

--- a/dbfit-java/mysql/src/test/java/dbfit/environment/StandaloneFixturesTest.java
+++ b/dbfit-java/mysql/src/test/java/dbfit/environment/StandaloneFixturesTest.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 import static fitnesse.junit.FitNesseSuite.*;
 
 @RunWith(FitNesseSuite.class)
-@Name("DbFit.AcceptanceTests.JavaTests.MysqlTests.StandaloneFixtures")
+@Name("DbFit.AcceptanceTests.JavaTests.MySqlTests.StandaloneFixtures")
 @FitnesseDir("../..")
 @OutputDir(systemProperty = "java.io.tmpdir", pathExtension = "fitnesse")
 @Port(1234)


### PR DESCRIPTION
Fixes typo introduced with baef54770fae69e0e80e71111aa619226326e291
