### PR TITLE
postgres adapter: support the unknown type

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/DataTypes/StringTests/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/DataTypes/StringTests/content.txt
@@ -7,9 +7,9 @@ Following types map to string: "VARCHAR", "CHAR", "TEXT"
 |s1|s2|s3|
 |VARCHAR|CHAR|TEXT|
 
-|Ordered Query|Select * from datatypetest|
-|s1?|s2?|s3?|
-|VARCHAR|CHAR|TEXT|
+|Ordered Query|Select s1, s2, s3, 'UNKNOWN' as s4 from datatypetest|
+|s1?|s2?|s3?|s4?|
+|VARCHAR|CHAR|TEXT|UNKNOWN|
 
 !3 should accept fail[null]
 

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/DataTypes/StringTests/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/DataTypes/StringTests/properties.xml
@@ -2,12 +2,10 @@
 <properties>
 	<Edit/>
 	<Files/>
-	<LastModified>20081117144823</LastModified>
 	<Properties/>
 	<RecentChanges/>
 	<Refactor/>
 	<Search/>
-	<Suites/>
 	<Test/>
 	<Versions/>
 	<WhereUsed/>

--- a/dbfit-java/postgres/src/main/java/dbfit/environment/PostgresEnvironment.java
+++ b/dbfit-java/postgres/src/main/java/dbfit/environment/PostgresEnvironment.java
@@ -1,17 +1,18 @@
 package dbfit.environment;
 
+import dbfit.annotations.DatabaseEnvironment;
+import dbfit.api.AbstractDbEnvironment;
+import dbfit.util.DbParameterAccessor;
+import dbfit.util.DbResultSetValueAccessor;
+import dbfit.util.NameNormaliser;
+
+import javax.sql.RowSet;
 import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.regex.Pattern;
 import java.util.*;
-
-import javax.sql.RowSet;
-
-import dbfit.api.AbstractDbEnvironment;
-import dbfit.util.*;
-import dbfit.annotations.DatabaseEnvironment;
+import java.util.regex.Pattern;
 
 @DatabaseEnvironment(name="Postgres", driver="org.postgresql.Driver")
 public class PostgresEnvironment extends AbstractDbEnvironment {
@@ -94,7 +95,7 @@ public class PostgresEnvironment extends AbstractDbEnvironment {
     // map types
     private static List<String> stringTypes = Arrays.asList(new String[] {
             "VARCHAR", "CHAR", "CHARACTER", "CHARACTER VARYING", "TEXT",
-            "NAME", "XML", "BPCHAR" });
+            "NAME", "XML", "BPCHAR", "UNKNOWN" });
     private static List<String> intTypes = Arrays.asList(new String[] {
             "SMALLINT", "INT", "INT4", "INT2", "INTEGER", "SERIAL" });
     private static List<String> longTypes = Arrays.asList(new String[] {


### PR DESCRIPTION
Adding support for the `unknown` type in Postgres. Without this, a "hello world" query wouldn't work:

```
select 'hello world'
```
