### PR TITLE
Introduce connection tests

### DIFF
--- a/FitNesseRoot/DbFit/ConnectionTests/DbFitFitSharp/content.txt
+++ b/FitNesseRoot/DbFit/ConnectionTests/DbFitFitSharp/content.txt
@@ -1,0 +1,1 @@
+!contents -R2 -g -p -f -h

--- a/FitNesseRoot/DbFit/ConnectionTests/DbFitFitSharp/properties.xml
+++ b/FitNesseRoot/DbFit/ConnectionTests/DbFitFitSharp/properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/MysqlConnectionTest/content.txt
+++ b/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/MysqlConnectionTest/content.txt
@@ -1,0 +1,7 @@
+!|dbfit.MySqlTest|
+
+!|Connect|localhost|dbfit_user|password|dbfit|
+
+!|Query|select 'hello world' as x|
+|x                               |
+|hello world                     |

--- a/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/MysqlConnectionTest/properties.xml
+++ b/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/MysqlConnectionTest/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Test>true</Test>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/OracleConnectionTest/content.txt
+++ b/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/OracleConnectionTest/content.txt
@@ -1,0 +1,7 @@
+!|dbfit.OracleTest|
+
+!|Connect|localhost:1521|dftest|dftest|XE|
+
+!|Query|select 'hello world' as x from dual|
+|x                                         |
+|hello world                               |

--- a/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/OracleConnectionTest/properties.xml
+++ b/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/OracleConnectionTest/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Test>true</Test>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/PostgresConnectionTest/content.txt
+++ b/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/PostgresConnectionTest/content.txt
@@ -1,0 +1,7 @@
+!|dbfit.PostgresTest|
+
+!|Connect|localhost:5432|dbfit|dbfit|dbfit|
+
+!|Query|select 'hello world' as x|
+|x                               |
+|hello world                     |

--- a/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/PostgresConnectionTest/properties.xml
+++ b/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/PostgresConnectionTest/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Test>true</Test>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/content.txt
+++ b/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/content.txt
@@ -1,0 +1,3 @@
+!path lib/*.jar
+
+!contents -R2 -g -p -f -h

--- a/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/properties.xml
+++ b/FitNesseRoot/DbFit/ConnectionTests/DbFitJava/properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/DbFit/ConnectionTests/content.txt
+++ b/FitNesseRoot/DbFit/ConnectionTests/content.txt
@@ -1,0 +1,1 @@
+!contents -R2 -g -p -f -h

--- a/FitNesseRoot/DbFit/ConnectionTests/properties.xml
+++ b/FitNesseRoot/DbFit/ConnectionTests/properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>


### PR DESCRIPTION
It would really good to have two steps in the `getting started` guide:
- a `hello world` part (checking the DbFit setup and connection to your database)
- a `writing your first test` part

This PR is introducing the `hello world` part.

Tasks:
- [x] connection test for Oracle
- [x] connection test for MySql
- [x] connection test for Postgres
- [ ] ~~connection test for DB2~~ (won't do this, as I don't have a DB2 instance to test against)
- [ ] connection test for SQL Server/Java
- [ ] connection test for SQL Server/FitSharp
- [ ] add connection tests to acceptance test suite
- [ ] integrate the connection tests in the 'getting started' guide
- [ ] annotate links with relevant docs sections
