### PR TITLE
Vagrant VM fix: don't mount filesystem using NFS in windows

### DIFF
--- a/test_vm/Vagrantfile
+++ b/test_vm/Vagrantfile
@@ -1,9 +1,12 @@
+require 'rbconfig'
+is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
+
 Vagrant::Config.run do |config|
   config.vm.box = "centos"
   config.vm.box_url = "https://dl.dropbox.com/u/31081437/Berkshelf-CentOS-6.3-x86_64-minimal.box"
   config.vm.host_name = "dbfitvm"
   config.vm.network :hostonly, "192.168.33.10"
-  config.vm.share_folder "dbfit", "/var/dbfit", "..", :nfs => true
+  config.vm.share_folder "dbfit", "/var/dbfit", "..", :nfs => !is_windows
 
   config.vm.provision :chef_solo do |chef|
     chef.add_recipe "dbfit_test"


### PR DESCRIPTION
Vagrant NFS mounting doesn't work under Windows, hence this fix.

The code here uses [a more robust way to determine a Windows system](http://stackoverflow.com/questions/4871309/what-is-the-correct-way-to-detect-if-ruby-is-running-on-windows) than d869d840a78dacb0312c3672b0e8ca40f0810752.
