### PR TITLE
swap evo-classindex for reflections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,12 +97,10 @@ An Eclipse project can be created by running:
 
     dbfit-java$ gradle eclipse
 
-**Note: the `dbfit-core` module uses [Evo Class Index library](https://github.com/atteo/evo-classindex), which requires [a workaround for Eclipse comilation to work](https://github.com/atteo/evo-classindex#eclipse).**
-
 #### Building
 
 *  Clean, build, test and install to local maven repo
-    
+
         dbfit-java$ gradle clean check install
 
 *  Build and package all java projects:

--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -66,7 +66,7 @@ project('core') {
     dependencies {
         compile "dummy:fitnesse-standalone:20130321@jar"
         compile "dummy:fitlibrary:20081102@jar"
-        compile "org.atteo:evo-classindex:1.4" // @jar suffix here doesn't pull dependencies (fails build)
+        compile "org.reflections:reflections:0.9.9-RC1"
         compile "commons-codec:commons-codec:1.7"
         testCompile "org.mockito:mockito-all:1.9.5"
     }

--- a/dbfit-java/core/src/main/java/dbfit/annotations/DatabaseEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/annotations/DatabaseEnvironment.java
@@ -4,11 +4,9 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.atteo.evo.classindex.IndexAnnotated;
 
 @Target(value = ElementType.TYPE)
 @Retention(value = RetentionPolicy.RUNTIME)
-@IndexAnnotated
 public @interface DatabaseEnvironment {
     String name();
     String driver();

--- a/dbfit-java/core/src/main/java/dbfit/api/DbEnvironmentFactory.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbEnvironmentFactory.java
@@ -1,15 +1,16 @@
 package dbfit.api;
 
-import dbfit.api.DBEnvironment;
 import dbfit.annotations.DatabaseEnvironment;
-import java.util.Map;
-import java.util.HashMap;
+import org.reflections.Reflections;
+
 import java.lang.reflect.Constructor;
-import org.atteo.evo.classindex.ClassIndex;
+import java.util.HashMap;
+import java.util.Map;
 
 public class DbEnvironmentFactory {
     private void initDefaultEnvironments() {
-        for (Class<?> c: ClassIndex.getAnnotated(DatabaseEnvironment.class)) {
+        Reflections reflections = new Reflections("dbfit");
+        for (Class<?> c: reflections.getTypesAnnotatedWith(DatabaseEnvironment.class)) {
             DatabaseEnvironment envAnnotation =
                 c.getAnnotation(DatabaseEnvironment.class);
             registerEnv(envAnnotation.name(), envAnnotation.driver());


### PR DESCRIPTION
There is some bug which prevents the `evo-classindex` annotation listings being generated when I run the tests from inside IntelliJ 12.1.4. On top of that, `evo-classindex` has that issue which forces Eclipse users to go through extra setup to get the project to work.

I've had a look, and the [`reflections` project](https://code.google.com/p/reflections/) seems like it's a lot more established (starred by 469 users on Google Code) compared to `evo` (only 9 stars on GitHub). 

Swapping the libraries out was very simple, and it looks like `reflections` should be very quick because you can limit it to analyse only classes in a specific package.

@javornikolov thoughts?
