### PR TITLE
serve the latest binary release from github releases

### DIFF
--- a/website/_config.yml
+++ b/website/_config.yml
@@ -18,6 +18,7 @@ author :
   twitter : benilov
 
 dbfit_version: "2.0.0-RC5"
+github_artifact_id: 321
 
 baseurl: /dbfit
 

--- a/website/index.html
+++ b/website/index.html
@@ -10,7 +10,7 @@ nav_bar_name: home
         <h1>DbFit</h1>
         <p class="lead">Test-driven database development. Write readable, easy-to-maintain unit and integration tests for your database code.</p>
         <p>
-          <a class="btn btn-large btn-success" href="https://s3.amazonaws.com/dbfit/dbfit-complete-{{ site.dbfit_version }}.zip" onclick="recordOutboundLink(this, 'Software', '{{ site.dbfit_version }}', 'Landing page');return false;">Download DbFit</a>
+          <a class="btn btn-large btn-success" href="https://github.com/benilovj/dbfit/releases/v{{ site.dbfit_version }}/{{ site.github_artifact_id }}/dbfit-complete-{{ site.dbfit_version | downcase }}.zip" onclick="recordOutboundLink(this, 'Software', '{{ site.dbfit_version }}', 'Landing page');return false;">Download DbFit</a>
           <a class="btn btn-large btn-primary" href="/dbfit/docs/" onclick="recordOutboundLink(this, 'Documentation', 'Documentation Index', 'Landing page');return false;">Documentation</a>
         </p>
 


### PR DESCRIPTION
the benefit of this change is that the binaries will no longer have to be
served from a private s3 bucket.

the unfortunate downside of this change is having to change another
variable whenever a release is done, namely the github_artifact_id
which looks like a counter of all github release binaries.
