### PR TITLE
refactor Execute fixture

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/api/DbStatement.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStatement.java
@@ -1,13 +1,10 @@
 package dbfit.api;
 
 import dbfit.fixture.StatementExecution;
-import dbfit.util.DbParameterAccessor;
 
 import java.sql.SQLException;
 
-import dbfit.util.Direction;
-
-public class DbStatement implements DbObject {
+public class DbStatement {
     private DBEnvironment environment;
     private String statementText;
     private TestHost testHost;
@@ -22,16 +19,7 @@ public class DbStatement implements DbObject {
         this.testHost = testHost;
     }
 
-    public StatementExecution buildPreparedStatement(DbParameterAccessor[] accessors) throws SQLException {
+    public StatementExecution buildPreparedStatement() throws SQLException {
         return new StatementExecution(environment.createStatementWithBoundFixtureSymbols(testHost, statementText), false);
-    }
-
-    public DbParameterAccessor getDbParameterAccessor(String paramName, Direction expectedDirection) {
-        return null;
-    }
-
-    @Override
-    public int getExceptionCode(SQLException e) {
-        return environment.getExceptionCode(e);
     }
 }

--- a/dbfit-java/core/src/main/java/dbfit/fixture/Execute.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/Execute.java
@@ -2,13 +2,12 @@ package dbfit.fixture;
 
 import dbfit.api.DBEnvironment;
 import dbfit.api.DbEnvironmentFactory;
-import dbfit.api.DbObject;
 import dbfit.api.DbStatement;
 import dbfit.util.FitNesseTestHost;
+import fit.Fixture;
+import fit.Parse;
 
-import java.sql.SQLException;
-
-public class Execute extends DbObjectExecutionFixture {
+public class Execute extends Fixture {
     private String statementText;
     private DBEnvironment dbEnvironment;
 
@@ -21,8 +20,18 @@ public class Execute extends DbObjectExecutionFixture {
         this.dbEnvironment = env;
     }
 
-    protected DbObject getTargetDbObject() throws SQLException {
-        if (statementText == null) statementText = args[0];
-        return new DbStatement(dbEnvironment, statementText, FitNesseTestHost.getInstance());
+    public void doRows(Parse rows) {
+        try {
+            DbStatement dbObject = new DbStatement(dbEnvironment, getStatementText(), FitNesseTestHost.getInstance());
+            StatementExecution preparedStatement = dbObject.buildPreparedStatement();
+            preparedStatement.run();
+        } catch (Throwable e) {
+            throw new Error(e);
+        }
+    }
+
+    private String getStatementText() {
+        if (statementText == null) statementText=args[0];
+        return statementText;
     }
 }


### PR DESCRIPTION
The Execute fixture no longer extends DbObjectExecutionFixture, because
there is no benefit to this.

This PR is extracted from #145.
