### PR TITLE
Add support for two additional datatypes (DB2)

### DIFF
--- a/dbfit-java/db2/src/main/java/dbfit/environment/DB2Environment.java
+++ b/dbfit-java/db2/src/main/java/dbfit/environment/DB2Environment.java
@@ -114,11 +114,11 @@ public class DB2Environment extends AbstractDbEnvironment {
     private static List<String> longTypes = Arrays
             .asList(new String[] { "BIGINT" });
     private static List<String> floatTypes = Arrays
-            .asList(new String[] { "FLOAT" });
+            .asList(new String[] { "FLOAT", "REAL" });
     private static List<String> doubleTypes = Arrays
             .asList(new String[] { "DOUBLE" });
     private static List<String> decimalTypes = Arrays.asList(new String[] {
-            "DECIMAL", "DEC", "DECFLOAT" });
+            "DECIMAL", "DEC", "DECFLOAT", "NUMERIC" });
     private static List<String> dateTypes = Arrays
             .asList(new String[] { "DATE" });
     private static List<String> timestampTypes = Arrays


### PR DESCRIPTION
Add support for zoned decimal (NUMERIC) and single-precision floating point (REAL) data types (DB2Environment).

I develop primarily on an IBM iSeries.  DB2 implementations vary a bit; there are even subtle differences between IBM's iSeries  (midrange) implementation and their zSeries (mainframe) implementation. 

Attached are diagrams from two of IBM's DB2 manuals, displaying the various data types supported by each DB2 implementation.  The first diagram shows the mainframe implementation, the second shows the midrange implementation.

![zos db2 data types](https://f.cloud.github.com/assets/4690013/927681/c5db38d4-ffa4-11e2-815b-c157815ce12d.jpg)

![i5os db2 data types](https://f.cloud.github.com/assets/4690013/927692/dfc74c9c-ffa4-11e2-8e18-2148b6f053f6.jpg)
