### PR TITLE
Isolate JDBC .getConnection in single method only

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
@@ -65,7 +65,7 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
 
         Properties props = new Properties();
         props.put("user", username);
-        props.put("password", password);
+        props.put("password", new PropertiesLoader().parseValue(password));
 
         connect(connectionString, props);
     }


### PR DESCRIPTION
Make all db connections go through `connect(connectionString, properties)` which is the single place to call JDBC `DriverManager.getConnection()`.
