### PR TITLE
Bump up travis to use oraclejdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: java
 install: "gradle assemble"
 script: "gradle clean fastbuild"
 jdk:
-  - oraclejdk6
+  - oraclejdk7
 after_success:
   - "gradle bundle"
   - "gem install travis-artifacts"


### PR DESCRIPTION
Seems Travis CI is failing with oraclejdk6. Bumping up to 7.
