### PR TITLE
Change test user in MySql standalone mode tests

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/MySqlTests/StandaloneFixtures/SetUp/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/MySqlTests/StandaloneFixtures/SetUp/content.txt
@@ -2,4 +2,4 @@
 |dbfit.fixture|
 
 !|DatabaseEnvironment|mysql|
-|Connect|localhost|root||dbfit|
+|Connect|localhost|dbfit_user|password|dbfit|


### PR DESCRIPTION
MySql standalone tests were based on _root_ database account which doesn't seem to be a good idea. (And also causes troubles with self-provisioned or customized database environment).

Switched that to the _standard_ MySql database user (which is used in FlowMode tests).
