### PR TITLE
fix function used in mysql acceptance test to work with enabled binlog

### DIFF
--- a/dbfit-java/mysql/src/test/resources/001_add_objects_needed_for_acceptance_test.sql
+++ b/dbfit-java/mysql/src/test/resources/001_add_objects_needed_for_acceptance_test.sql
@@ -4,7 +4,7 @@ CREATE PROCEDURE ConcatenateStrings (IN firststring varchar(100), IN secondstrin
 
 create procedure CalcLength(IN name varchar(100), OUT strlength int) set strlength =length(name);
 
-CREATE FUNCTION ConcatenateF (firststring  VARCHAR(100), secondstring varchar(100)) RETURNS VARCHAR(200) RETURN CONCAT(firststring,' ',secondstring);
+CREATE FUNCTION ConcatenateF (firststring  VARCHAR(100), secondstring varchar(100)) RETURNS VARCHAR(200) DETERMINISTIC RETURN CONCAT(firststring,' ',secondstring);
 
 create procedure makeuser() insert into users (name,username) values ('user1','fromproc');
 


### PR DESCRIPTION
This was raised by @phe1129 (closes #180, supercedes #182 and #184).

When `binlog` is enabled and the `log_bin_trust_function_creators` system variable
is OFF (default=OFF), MySQL requires Create Function DDL to specify whether `DETERMINISTIC`,
`NO SQL`, or `READS SQL DATA` in its declaration. Otherwise the server gives exception.
For more details: http://dev.mysql.com/doc/refman/5.5/en/stored-programs-logging.html
