### PR TITLE
Refine vagrant nfs mount options to avoid locking issues

### DIFF
--- a/test_vm/Vagrantfile
+++ b/test_vm/Vagrantfile
@@ -6,7 +6,8 @@ Vagrant::Config.run do |config|
   config.vm.box_url = "https://dl.dropbox.com/u/31081437/Berkshelf-CentOS-6.3-x86_64-minimal.box"
   config.vm.host_name = "dbfitvm"
   config.vm.network :hostonly, "192.168.33.10"
-  config.vm.share_folder "dbfit", "/var/dbfit", "..", :nfs => !is_windows
+  config.vm.share_folder "dbfit", "/var/dbfit", "..", :nfs => !is_windows,
+    :nfs_version => 4, :mount_options => ["noatime", "nodiratime"]
 
   config.vm.provision :chef_solo do |chef|
     chef.add_recipe "dbfit_test"


### PR DESCRIPTION
Since a while I've been facing problem with the nfs mount options - gradle used to abort due to failure of locking some cache files. _(I'm not sure when I faced the locking issue for first time: it's either due to updates in my Ubuntu or due to vagrant updates)._

I managed to workaround the problem by either by:
- mounting the nfs with `ver=4` (instead of `ver=3`)
- or by adding `nolock` option

The `no*atime` changes are just general performance suggestions (not related to fixing errors).

The changes in this PR work fine for me with current version of vagrant (`1.4.1`) on Ubuntu 13.10 64-bit.
