### PR TITLE
Convert SqlServerRegressionTest to use the FitNesseSuite runner

### DIFF
--- a/dbfit-java/sqlserver/src/test/java/dbfit/environment/SqlServerRegressionTest.java
+++ b/dbfit-java/sqlserver/src/test/java/dbfit/environment/SqlServerRegressionTest.java
@@ -1,30 +1,29 @@
 package dbfit.environment;
 
-import fitnesse.junit.JUnitHelper;
-import org.junit.Before;
+import fitnesse.junit.FitNesseSuite;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import java.io.File;
+import static fitnesse.junit.FitNesseSuite.*;
 
 @Ignore
 public class SqlServerRegressionTest {
-
-    private JUnitHelper helper;
-
-    @Before
-    public void setUp() {
-        helper = new JUnitHelper("../..", new File("../../tmp").getAbsolutePath());
-        helper.setPort(1234);
+    @RunWith(FitNesseSuite.class)
+    @Name("AcceptanceTests.JavaTests.SqlServerTests.FlowMode")
+    @FitnesseDir("../..")
+    @OutputDir("../../tmp")
+    @Port(1234)
+    public static class FlowModeTest {
+        @Test public void dummy(){}
     }
 
-    @Test
-    public void flowMode() throws Exception {
-        helper.assertSuitePasses("AcceptanceTests.JavaTests.SqlServerTests.FlowMode");
-    }
-
-    @Test
-    public void standaloneMode() throws Exception {
-        helper.assertSuitePasses("AcceptanceTests.JavaTests.SqlServerTests.StandaloneFixtures");
+    @RunWith(FitNesseSuite.class)
+    @Name("AcceptanceTests.JavaTests.SqlServerTests.StandaloneFixtures")
+    @FitnesseDir("../..")
+    @OutputDir("../../tmp")
+    @Port(1234)
+    public static class StandaloneFixturesTest {
+        @Test public void dummy(){}
     }
 }


### PR DESCRIPTION
JUnitRunner has been removed from the latest versions of Fitnesse.

This change means that these tests will continue to at least compile, but to be honest, I don't know what to do with them. These obviously need an SqlServer instance to run, I haven't run them in a very long time because of the hassle and so I don't know whether they even pass anymore.
