### PR TITLE
Move config settings away from the startup shell script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,10 @@ task copyLocal(dependsOn: [cleanFitnesseroot, cleanDist, ':dbfit-java:assembleAl
         filter(ReplaceTokens,
             tokens: ['dbfitVersion': dbfitVersion, 'fitNesseVersion': project(':dbfit-java').fitNesseVersion])
     }
-    file('dist/plugins.properties') << 'Theme=bootstrap'
+    copy {
+        from 'files'
+        into 'dist'
+    }
     copy {
         from 'dbfit-java'
         include '**/*.jar'

--- a/files/plugins.properties
+++ b/files/plugins.properties
@@ -1,0 +1,3 @@
+Theme=bootstrap
+Port=8085
+VersionsController.days=0

--- a/templates/startFitnesse.bat.tmpl
+++ b/templates/startFitnesse.bat.tmpl
@@ -1,3 +1,3 @@
 cd /d %~dp0
-java -cp 'lib\dbfit-docs-@dbfitVersion@.jar:lib\fitnesse-standalone-@fitNesseVersion@.jar' fitnesseMain.FitNesseMain -p 8085 -e 0 %1 %2 %3 %4 %5
+java -cp 'lib\dbfit-docs-@dbfitVersion@.jar:lib\fitnesse-standalone-@fitNesseVersion@.jar' fitnesseMain.FitNesseMain %*
 pause

--- a/templates/startFitnesse.sh.tmpl
+++ b/templates/startFitnesse.sh.tmpl
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd `dirname $0`
-java -cp 'lib/dbfit-docs-@dbfitVersion@.jar:lib/fitnesse-standalone-@fitNesseVersion@.jar' fitnesseMain.FitNesseMain -p 8085 -e 0 $1 $2 $3 $4 $5
+java -cp 'lib/dbfit-docs-@dbfitVersion@.jar:lib/fitnesse-standalone-@fitNesseVersion@.jar' fitnesseMain.FitNesseMain $@


### PR DESCRIPTION
This is to allow overwriting parameters (e.g. port) without changing shell script. This is to target issues like:
- Having customized shell script complicates dbfit upgrades (especially now when we have version numbers embedded in the script)
- Having hard-coded port prevents running multiple dbfit servers with same script
