### PR TITLE
Vagrantfile vm memory customization support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ test_vm/cookbooks
 test_vm/.vagrant
 test_vm/tmp
 test_vm/Disk1
+test_vm/vagrantconfig-local.yaml
 oracle-xe-*.rpm.zip
 
 # the documentation

--- a/test_vm/Vagrantfile
+++ b/test_vm/Vagrantfile
@@ -3,12 +3,14 @@
 
 require 'rbconfig'
 is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
+local_config_path = File.expand_path("../vagrantconfig-local.yaml", __FILE__)
+CONFIG = File.exist?(local_config_path) ? YAML.load(File.read(local_config_path)) : {}
 
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "1100"]
+    vb.customize ["modifyvm", :id, "--memory", CONFIG['memory'] || "1100"]
   end
 
   config.omnibus.chef_version = :latest


### PR DESCRIPTION
Allow overriding default vm memory Vagrantfile settings so that  in case of RAM shortage one can tweak it without changing the checked-in Vagrantfile.
