### PR TITLE
Fix path separator for startFitnesse.bat

### DIFF
--- a/templates/startFitnesse.bat.tmpl
+++ b/templates/startFitnesse.bat.tmpl
@@ -1,3 +1,3 @@
 cd /d %~dp0
-java -cp 'lib\dbfit-docs-@dbfitVersion@.jar:lib\fitnesse-standalone-@fitNesseVersion@.jar' fitnesseMain.FitNesseMain %*
+java -cp 'lib\dbfit-docs-@dbfitVersion@.jar;lib\fitnesse-standalone-@fitNesseVersion@.jar' fitnesseMain.FitNesseMain %*
 pause


### PR DESCRIPTION
Fix for bug discovered while working on #234
Path separator for windows should be ";" instead of ":"
