### PR TITLE
Fix startFitnesse.bat.tmpl quotes around classpath

### DIFF
--- a/templates/startFitnesse.bat.tmpl
+++ b/templates/startFitnesse.bat.tmpl
@@ -1,3 +1,3 @@
 cd /d %~dp0
-java -cp 'lib\dbfit-docs-@dbfitVersion@.jar;lib\fitnesse-standalone-@fitNesseVersion@.jar' fitnesseMain.FitNesseMain %*
+java -cp "lib\dbfit-docs-@dbfitVersion@.jar;lib\fitnesse-standalone-@fitNesseVersion@.jar" fitnesseMain.FitNesseMain %*
 pause


### PR DESCRIPTION
Windows .bat files don't support single `'` quotes. Replaced with double `"`

Related discussion is in #234
