### PR TITLE
Gradle task to run dbfit on actual tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,13 @@ task start(type: Exec, dependsOn: [copyLocal, copyExtraLibs, wikiDocs, bundleFit
     executable onWindows() ? 'startFitnesse.bat' : './startFitnesse.sh'
 }
 
+task starthere(type: Exec, dependsOn: [copyLocal, copyExtraLibs]) {
+    workingDir './dist'
+    description = 'starts fitness with dbfit on top of real tests sources'
+    executable onWindows() ? 'startFitnesse.bat' : './startFitnesse.sh'
+    args '-d', '..', '-o', '-f', 'plugins.properties'
+}
+
 task fastbuild(dependsOn: [':dbfit-java:core:check', ':dbfit-java:derby:check'])
 
 def onWindows() {


### PR DESCRIPTION
Added gradle `starthere` task which runs DbFit on top of the actual acceptance tests (instead of their dist copy):
- Provides access for editing the actual acceptance tests
- Speeds up the startup since is skipping: `fitsharp` and `wikidocs` & their unpacking
