### PR TITLE
MS SQL Server: allow connections to datasource\namedInstance

### DIFF
--- a/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
+++ b/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
@@ -32,24 +32,9 @@ public class SqlServerEnvironment extends AbstractDbEnvironment {
         return false;
     }
 
-    private String getInstanceString(String s) {
-
-        int idx = s.indexOf('\\');
-        if (idx > 0) {
-            throw new UnsupportedOperationException(
-                    "Java SQL Server Driver does not work with instance names. "
-                            + "Create an alias for your SQL Server Instance.");
-            // String server = s.substring(0, idx);
-            // String instance = s.substring(idx + 1);
-            // System.out.println(server + ";instanceName=" + instance);
-            // return "localhost;instanceName=" + instance;
-        }
-        return s;
-    }
-
     @Override
     protected String getConnectionString(String dataSource) {
-        return "jdbc:sqlserver://" + getInstanceString(dataSource);
+        return "jdbc:sqlserver://" + dataSource;
     }
 
     @Override


### PR DESCRIPTION
There used to be explicit check which forbids connection via dataSource = `host\<instance name>`. That seems to be working fine now (tested with SQL Sever Express 2014) so I'm removing this restriction.

Example connection definitions which work fine with named instances:
- Via backslash prefix:

```
!|Connect|myhost\myinstance|myuser|mypassword|mydbname|
```
- By setting parameter `instanceName=...`:

```
!|Connect|myhost;instanceName=myinstance|myuser|mypassword|mydbname|
```
- Via raw JDBC URL works too:

```
!|Connect|jdbc:sqlserver://myhost\myinstance;user=myuser;password=mypassword;databaseName=mydbname|
```

Connection to named instance requires MS SQL Server Browser service to be up and running and allowed by firewalls (if any). Each database should be also configured to accept TCP/IP connections (including allowance in firewall if any).

This targets to fix #120 
