### PR TITLE
install_oracle.sh: don't abort if can't remove setup files after install

### DIFF
--- a/dbfit-java/oracle/src/test/resources/install_oracle.sh
+++ b/dbfit-java/oracle/src/test/resources/install_oracle.sh
@@ -41,3 +41,5 @@ su -s /bin/bash oracle -c "${CONFIG_CMD}" || { echo "Config via '${CONFIG_CMD}' 
 
 rm -rf $RPM_PATH/Disk1
 
+exit 0
+


### PR DESCRIPTION
This is to avoid vagrant provisioning die just because setup files cannot be cleaned up. (Depending on specifics of host file system - removal may be forbidden).
