### PR TITLE
Scripts and documentation of the release process

### DIFF
--- a/releasing/Gemfile
+++ b/releasing/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'octokit'
+gem 'travis'

--- a/releasing/Gemfile.lock
+++ b/releasing/Gemfile.lock
@@ -1,0 +1,63 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.6)
+    backports (3.6.0)
+    coderay (1.1.0)
+    ethon (0.7.0)
+      ffi (>= 1.3.0)
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.9.1)
+      faraday (>= 0.7.4, < 0.10)
+    ffi (1.9.3)
+    gh (0.13.2)
+      addressable
+      backports
+      faraday (~> 0.8)
+      multi_json (~> 1.0)
+      net-http-persistent (>= 2.7)
+      net-http-pipeline
+    highline (1.6.21)
+    json (1.8.1)
+    launchy (2.4.2)
+      addressable (~> 2.3)
+    method_source (0.8.2)
+    multi_json (1.10.0)
+    multipart-post (2.0.0)
+    net-http-persistent (2.9.4)
+    net-http-pipeline (1.0.1)
+    octokit (3.1.0)
+      sawyer (~> 0.5.3)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    pusher-client (0.6.0)
+      json
+      websocket (~> 1.0)
+    sawyer (0.5.4)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
+    slop (3.5.0)
+    travis (1.6.10)
+      addressable (~> 2.3)
+      backports
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9)
+      gh (~> 0.13)
+      highline (~> 1.6)
+      launchy (~> 2.1)
+      pry (~> 0.9)
+      pusher-client (~> 0.4)
+      typhoeus (~> 0.6)
+    typhoeus (0.6.8)
+      ethon (>= 0.7.0)
+    websocket (1.1.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  octokit
+  travis

--- a/releasing/README.md
+++ b/releasing/README.md
@@ -1,0 +1,44 @@
+# Releasing DbFit
+
+1. Make sure that all issues and pull requests on master since the last release:
+    - are assigned to a milestone
+    - are labelled with one of `enhancement`, `bugfix`, etc
+    - all have meaningful titles (since they'll appear in the release notes)
+
+2. Pick a release number, according to the [SemVer conventions](http://semver.org/), eg `3.2.1`.
+
+3. Make sure than the milestone name matches the release number.
+
+4. Bump (and push) the release number in:
+    - the Gradle build (`./build.gradle`)
+    - the website docs (`website/_config.yml`)
+
+5. Fetch the build artefact from S3:
+
+        releasing$ bundle exec ./fetch_last_successful_artefact
+
+6. Smoke test the package by:
+    - unpacking the archive
+    - launching DbFit
+    - running some acceptance tests
+
+7. Once you're happy everything works, create and push a git tag with the release:
+
+        git tag -a v<release number> -m 'Release <release number>'
+        git push origin --tags
+
+8. Generate a draft of the release notes:
+
+        releasing$ bundle exec ./generate_release_notes <release number>
+
+9. [Create a GitHub release](https://github.com/dbfit/dbfit/releases/new) using the GitHub tag and the release notes. I try to always summarise the contents of the release in the first few sentences.
+
+10. Update the website by promoting the `master` docs to `gh-pages`:
+
+        $ bin/publish-to-gh-pages.sh
+
+11. Verify that the [DbFit website](http://dbfit.github.io/dbfit/) built correctly and that the download link to the new release is correct.
+
+12. Announce the release on the [DbFit Google groups](https://groups.google.com/forum/#!topic/dbfit). I always pin the announcement as the top topic, and unpin the announcement about the previous release.
+
+13. Optionally, tweet about the release :)

--- a/releasing/fetch_last_successful_artefact
+++ b/releasing/fetch_last_successful_artefact
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+require 'travis'
+
+S3_BASE_URL = "https://s3.amazonaws.com/dbfit"
+
+def artefact_url_from_last_successful_job
+  job = last_successful_jdk7_job
+  relative_url = job.log.clean_body.scan(/Uploading file .*? to (.*?), public: true/).flatten.first
+  commit = job.commit
+  { url: "#{S3_BASE_URL}/#{relative_url}", commit_message: "#{commit.author_name} - #{commit.subject}" }
+end
+
+def last_successful_jdk7_job
+  repo = Travis::Repository.find('dbfit/dbfit')
+  last_successful_build = repo.builds.detect(&:passed?)
+  last_successful_build.jobs.inspect # workaround for lazy loading, so that the next line works
+  last_successful_build.jobs.detect { |job| job.attributes["config"]["jdk"] == "oraclejdk7" }
+end
+
+artefact = artefact_url_from_last_successful_job
+puts "Downloading: #{artefact[:url]}"
+puts "Commit: #{artefact[:commit_message]}"
+puts ""
+
+`wget #{artefact[:url]}`

--- a/releasing/generate_release_notes
+++ b/releasing/generate_release_notes
@@ -1,0 +1,84 @@
+#!/usr/bin/env ruby
+
+require 'date'
+require 'octokit'
+
+Octokit.auto_paginate = true
+
+class DbFitIssue
+  ISSUES_RELEVANT_TO_RELEASE_NOTES = [ 'enhancement', 'docs', 'bugfix' ]
+
+  def initialize(issue)
+    @issue = issue
+  end
+
+  def to_markdown
+    "* #{@issue.title} ([##{@issue.number}](#{@issue.html_url}))"
+  end
+
+  def milestone_title
+    @issue.milestone ? @issue.milestone.title : nil
+  end
+
+  def applies_to_release_notes?
+    not (ISSUES_RELEVANT_TO_RELEASE_NOTES & label_names).empty?
+  end
+
+  def has_label?(label)
+    label_names.include?(label)
+  end
+
+  private
+  def label_names
+    @issue.labels.map(&:name)
+  end
+end
+
+class ReleaseNotes
+  SECTIONS_AND_LABELS = {
+    "New features" => "enhancement",
+    "Minor improvements and bugfixes" => "bugfix",
+    "Documentation improvements" => "docs"
+  }
+
+  def initialize(milestone_title)
+    @milestone_title = milestone_title
+  end
+
+  def to_markdown
+    heading + "\n\n" + sections.join("\n")
+  end
+
+  private
+  def heading
+    "## Release date: #{Date.today.strftime("%-d %B %Y")}"
+  end
+
+  def sections
+    SECTIONS_AND_LABELS.map do |section_heading, relevant_label|
+      "### #{section_heading}\n\n" +
+        issues_for_milestone.
+        select { |issue| issue.has_label?(relevant_label) }.
+        map(&:to_markdown).
+        join("\n") + "\n"
+    end
+  end
+
+  def issues_for_milestone
+    all_issues.select { |issue| issue.milestone_title == @milestone_title }
+  end
+
+  def all_issues
+    @all_issues ||= Octokit.issues('dbfit/dbfit', state: "closed").
+      map { |issue| DbFitIssue.new(issue) }.
+      select(&:applies_to_release_notes?)
+  end
+end
+
+if ARGV.empty?
+  puts "Usage: #{$0} <GitHub milestone>"
+  exit 1
+end
+
+github_milestone = ARGV[0]
+puts ReleaseNotes.new(github_milestone).to_markdown


### PR DESCRIPTION
This was used for the 3.0.0 release.

It's ideal that this re-introduces ruby back into the repo (the same scripts could
probably be done with Groovy) but this is a good first strawman.
