### PR TITLE
Set non-empty db2 driver artifact group

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -87,7 +87,7 @@ project('db2') {
 
     dependencies {
         compile project(':dbfit-java:core')
-        runtime ':db2jcc4:4.17.29@jar'
+        runtime 'com.ibm.db2:db2jcc4:4.17.29@jar'
     }
 }
 


### PR DESCRIPTION
This is to avoid POM-related errors when running gradle `install` task like following one:

```
:dbfit-java:db2:install FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':dbfit-java:db2:install'.
> Could not publish configuration 'archives'
> Unable to initialize POM pom-default.xml: Failed to validate POM for project com.neuri.dbfit:dbfit-db2 at /var/dbfit2/dbfit-java/db2/build/poms/pom-default.xml
```
