### PR TITLE
Handle nulls in fixture tables using setNull to fix Teradata failures

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/TeradataTests/FlowMode/DataTypes/DateTests/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/TeradataTests/FlowMode/DataTypes/DateTests/content.txt
@@ -18,7 +18,6 @@ Following types map to Date/Time: "TIMESTAMP" ,"DATE", "TIME".
 
 |Execute Ddl|Delete from datatypetest|
 
-NULL handling tests currently disabled {{{
 |Insert|datatypetest|
 |d1|ts1|t1|
 |null|null|null|
@@ -26,4 +25,3 @@ NULL handling tests currently disabled {{{
 |Query|Select * from datatypetest|
 |d1|ts1|t1|
 |null|null|null|
-}}}

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/TeradataTests/FlowMode/DataTypes/NumberTests/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/TeradataTests/FlowMode/DataTypes/NumberTests/content.txt
@@ -7,16 +7,12 @@ All numbers map to decimal, except float which maps to float
 |Insert|datatypetest|
 |n2|n3|f|n4|n5|n6|n7|
 |11|10.88|13.1|113|123.45|45678|56.789|
-
-Null handling tests currently disabled {{{
-|null|null|null|null|null|null|null|}}}
+|null|null|null|null|null|null|null|
 
 |Query|Select * from datatypetest|
 |n2|n3?|f?|n4?|n5?|n6?|n7|
 |11|10.88|13.1|113|123.45|45678|56.789|
-
-Null handling tests currently disabled {{{
-|null|null|null|null|null|null|null|}}}
+|null|null|null|null|null|null|null|
 
 |Ordered Query|Select * from datatypetest where n3=10.88|
 |n2|n3|f|n4|n5|n6|n7|

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/TeradataTests/FlowMode/ParametersAreLoadedAutomaticallyFromVariables/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/TeradataTests/FlowMode/ParametersAreLoadedAutomaticallyFromVariables/content.txt
@@ -5,9 +5,7 @@ Parameters are loaded automatically from variables, no need to set them explicit
 |pera|Petar Detlic|1|
 |Mika|Mitar Miric|2|
 |Zeka|Dusko Dugousko|3|
-
-Null handling tests currently disabled {{{
-|DevNull|null|4|}}}
+|DevNull|null|4|
 
 |Query|Select userid from Users where username = 'pera'|
 |userid?|

--- a/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
@@ -28,8 +28,14 @@ public class StatementExecution implements AutoCloseable {
         convertStatementToCallable().registerOutParameter(index, sqlType);
     }
 
-    public void setObject(int index, Object value) throws SQLException {
-        statement.setObject(index, value);
+    public void setObject(int index, Object value, int sqlType) throws SQLException {
+        if (value == null) {
+            statement.setNull(index, sqlType);
+        } else {
+            // Don't use the variant that takes sqlType.
+            // Derby (at least) assumes no decimal places for Types.DECIMAL and truncates the source data.
+            statement.setObject(index, value);
+        }
     }
 
     public Object getObject(int index) throws SQLException {

--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
@@ -71,7 +71,7 @@ public class DbParameterAccessor {
     public void set(Object value) throws Exception {
         if (direction == OUTPUT|| direction == RETURN_VALUE)
             throw new UnsupportedOperationException("Trying to set value of output parameter "+name);
-        cs.setObject(index, value);
+        cs.setObject(index, value, sqlType);
     }    
 
     public Object get() throws IllegalAccessException, InvocationTargetException {


### PR DESCRIPTION
This change fixes some of the `null` handing issues with the Teradata adapter.

This also allows us to use the `CoreTests` suite as there are no `null` parameters (set via `Set Parameter`) used.

Partially resolves #318.
