### PR TITLE
AbstractDbEnvironment: move setAutocommit(false) to afterConnectionEstablished

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
@@ -42,13 +42,12 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
      * Intended to be overriden for post-connect activities
      */
     protected void afterConnectionEstablished() throws SQLException {
-        // empty stub
+        currentConnection.setAutoCommit(false);
     }
 
     public void connect(String connectionString, Properties info) throws SQLException {
         registerDriver();
         currentConnection = DriverManager.getConnection(connectionString, info);
-        currentConnection.setAutoCommit(false);
         afterConnectionEstablished();
     }
 


### PR DESCRIPTION
This is to allow easier overriding of post-connect behaviour, especially in environments where transactions are not supported. (In particular - this is supposed to help #326).
