### PR TITLE
fixed java.lang.NumberFormatException ...

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/util/BigDecimalParseDelegate.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/BigDecimalParseDelegate.java
@@ -1,13 +1,15 @@
 package dbfit.util;
 
 import java.math.BigDecimal;
-import java.text.NumberFormat;
+import java.text.DecimalFormat;
 import java.text.ParseException;
 
 public class BigDecimalParseDelegate {
-    private static NumberFormat nf = NumberFormat.getInstance();
+    private static DecimalFormat nf = new DecimalFormat();
+
     public static Object parse(String s) {
         try {
+            nf.setParseBigDecimal(true);
             return new NormalisedBigDecimal(new BigDecimal(nf.parse(s).toString()));
         } catch (ParseException e) {
             return new NormalisedBigDecimal(new BigDecimal(s));

--- a/dbfit-java/core/src/main/java/dbfit/util/BigDecimalParseDelegate.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/BigDecimalParseDelegate.java
@@ -1,9 +1,16 @@
 package dbfit.util;
 
 import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.text.ParseException;
 
 public class BigDecimalParseDelegate {
+    private static NumberFormat nf = NumberFormat.getInstance();
     public static Object parse(String s) {
-        return new NormalisedBigDecimal(new BigDecimal(s));
+        try {
+            return new NormalisedBigDecimal(new BigDecimal(nf.parse(s).toString()));
+        } catch (ParseException e) {
+            return new NormalisedBigDecimal(new BigDecimal(s));
+        }
     }
 }

--- a/dbfit-java/core/src/test/java/dbfit/util/BigDecimalParseDelegateLocaleTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/BigDecimalParseDelegateLocaleTest.java
@@ -13,7 +13,7 @@ public class BigDecimalParseDelegateLocaleTest {
     public void aDecimalOfLocaleFormatIsParsed() {
         DecimalFormatSymbols dfs = new DecimalFormatSymbols(Locale.getDefault());
         BigDecimalNormaliser bdn = new BigDecimalNormaliser();
-        BigDecimal bd1 = (BigDecimal) bdn.normalise(new BigDecimal(111.111));
+        BigDecimal bd1 = (BigDecimal) bdn.normalise(new BigDecimal("111.111"));
         BigDecimal bd2 = (BigDecimal) bdn.normalise(BigDecimalParseDelegate.parse("111" + dfs.getDecimalSeparator() + "111"));
         assertEquals(bd1, bd2);
     }

--- a/dbfit-java/core/src/test/java/dbfit/util/BigDecimalParseDelegateLocaleTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/BigDecimalParseDelegateLocaleTest.java
@@ -1,0 +1,21 @@
+package dbfit.util;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+import static org.junit.Assert.*;
+
+public class BigDecimalParseDelegateLocaleTest {
+    @Test
+    public void aDecimalOfLocaleFormatIsParsed() {
+        DecimalFormatSymbols dfs = new DecimalFormatSymbols(Locale.getDefault());
+        BigDecimalNormaliser bdn = new BigDecimalNormaliser();
+        BigDecimal bd1 = (BigDecimal) bdn.normalise(new BigDecimal(111.111));
+        BigDecimal bd2 = (BigDecimal) bdn.normalise(BigDecimalParseDelegate.parse("111" + dfs.getDecimalSeparator() + "111"));
+        assertEquals(bd1, bd2);
+    }
+
+}

--- a/dbfit-java/core/src/test/java/dbfit/util/BigDecimalParseDelegateLocaleTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/BigDecimalParseDelegateLocaleTest.java
@@ -9,13 +9,36 @@ import java.util.Locale;
 import static org.junit.Assert.*;
 
 public class BigDecimalParseDelegateLocaleTest {
+    private char ds = new DecimalFormatSymbols(Locale.getDefault()).getDecimalSeparator();
+    private BigDecimalNormaliser normaliser = new BigDecimalNormaliser();
+
     @Test
     public void aDecimalOfLocaleFormatIsParsed() {
-        DecimalFormatSymbols dfs = new DecimalFormatSymbols(Locale.getDefault());
-        BigDecimalNormaliser bdn = new BigDecimalNormaliser();
-        BigDecimal bd1 = (BigDecimal) bdn.normalise(new BigDecimal("111.111"));
-        BigDecimal bd2 = (BigDecimal) bdn.normalise(BigDecimalParseDelegate.parse("111" + dfs.getDecimalSeparator() + "111"));
+        BigDecimal bd1 = normalise(new BigDecimal("111.111"));
+        BigDecimal bd2 = normalise(BigDecimalParseDelegate.parse("111" + ds + "111"));
         assertEquals(bd1, bd2);
+    }
+
+    @Test
+    public void aHugeDecimalOfLocaleFormatIsParsed() {
+        BigDecimal bd1 = normalise(new BigDecimal("123456789012345.123456789012345"));
+        BigDecimal bd2 = normalise(BigDecimalParseDelegate.parse("123456789012345" + ds + "123456789012345"));
+        assertEquals(bd1, bd2);
+    }
+
+    @Test
+    public void aNegativeDecimalOfLocaleFormatIsParsed() {
+        BigDecimal bd1 = normalise(new BigDecimal("-98765.0000111"));
+        BigDecimal bd2 = normalise(BigDecimalParseDelegate.parse("-98765" + ds + "0000111"));
+        assertEquals(bd1, bd2);
+    }
+
+    private BigDecimal normalise(BigDecimal val) {
+        return (BigDecimal) normaliser.normalise(val);
+    }
+
+    private BigDecimal normalise(Object val) {
+        return (BigDecimal) normaliser.normalise(val);
     }
 
 }


### PR DESCRIPTION
when using decimal values with locales having a decimal separator other than "."

https://groups.google.com/forum/#!msg/dbfit/2JNsutqfVV4/8Br6jx9Eh7cJ

My tests are working now, but "gradle clean fastbuild" throws java.lang.AssertionError: wrong expected:<0> but was:<4> in test classMethod.

It'll certainly break things for people who rely on the number format to use a period as decimal separator. I was trying to find out how date/timestamp related tests deal with different locales, but didn't find any. Perhaps we'll need an option to specify the locale per page.

Resolves #297