### PR TITLE
DbFit build/test: add support for Oracle connection customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ build
 .gradle
 target
 dbfit-complete-*.zip
+dbfit-java/oracle/TestDbConnectionDbFitOracle.properties
+dbfit-java/oracle/TestDbConnectionDbFitOracle.properties.custom

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/OracleTests/FlowMode/SetUp/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/OracleTests/FlowMode/SetUp/content.txt
@@ -1,3 +1,3 @@
 !|dbfit.OracleTest|
 
-|Connect|localhost:1521|dftest|dftest|XE|
+!|ConnectUsingFile|TestDbConnectionDbFitOracle.properties|

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/OracleTests/FlowMode/SetUp/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/OracleTests/FlowMode/SetUp/properties.xml
@@ -2,7 +2,6 @@
 <properties>
 	<Edit>true</Edit>
 	<Files>true</Files>
-	<LastModified>20090309163143</LastModified>
 	<Properties>true</Properties>
 	<RecentChanges>true</RecentChanges>
 	<Refactor>true</Refactor>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/OracleTests/StandaloneFixtures/SetUp/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/OracleTests/StandaloneFixtures/SetUp/content.txt
@@ -2,4 +2,4 @@
 |dbfit.fixture|
 
 !|DatabaseEnvironment|oracle|
-|connect|localhost:1521|dftest|dftest|xe|
+|ConnectUsingFile|TestDbConnectionDbFitOracle.properties|

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,20 @@ task copyExtraLibs(dependsOn: [copyLocal]) << {
     }
 }
 
+task copyConnections(dependsOn: [copyLocal]) << {
+    copy {
+        from 'dbfit-java/oracle/TestDbConnectionDbFitOracle.properties.default'
+        into 'dist'
+        rename '(.*).default', '$1'
+    }
+
+    copy {
+        from 'dbfit-java/oracle/TestDbConnectionDbFitOracle.properties.custom'
+        into 'dist'
+        rename '(.*).custom', '$1'
+    }
+}
+
 task wikiDocsDir << {
     mkdir('docs/Resources/')
 }
@@ -137,13 +151,13 @@ task bundle(type: Zip, dependsOn: [copyLocal, wikiDocs, bundleFitsharp]) {
     destinationDir new File('zips')
 }
 
-task start(type: Exec, dependsOn: [copyLocal, copyExtraLibs, wikiDocs, bundleFitsharp]) {
+task start(type: Exec, dependsOn: [copyLocal, copyExtraLibs, copyConnections, wikiDocs, bundleFitsharp]) {
     workingDir './dist'
     description = 'starts fitness with dbfit'
     executable onWindows() ? 'startFitnesse.bat' : './startFitnesse.sh'
 }
 
-task starthere(type: Exec, dependsOn: [copyLocal, copyExtraLibs]) {
+task starthere(type: Exec, dependsOn: [copyLocal, copyExtraLibs, copyConnections]) {
     workingDir './dist'
     description = 'starts fitness with dbfit on top of real tests sources'
     executable onWindows() ? 'startFitnesse.bat' : './startFitnesse.sh'

--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -124,6 +124,20 @@ project('oracle') {
         compile 'dummy:ojdbc6:11.2.0.3.0@jar'
         testCompile "org.mockito:mockito-all:1.9.5"
     }
+
+    test.doFirst {
+        copy {
+            from 'TestDbConnectionDbFitOracle.properties.default'
+            into '.'
+            rename '(.*).default', '$1'
+        }
+
+        copy {
+            from 'TestDbConnectionDbFitOracle.properties.custom'
+            into '.'
+            rename '(.*).custom', '$1'
+        }
+    }
 }
 
 project('mysql') {

--- a/dbfit-java/oracle/TestDbConnectionDbFitOracle.properties.default
+++ b/dbfit-java/oracle/TestDbConnectionDbFitOracle.properties.default
@@ -1,0 +1,3 @@
+service=localhost:1521/xe
+username=dftest
+password=dftest


### PR DESCRIPTION
This is to allow running DbFit acceptance tests with a non-default Oracle instance
