### PR TITLE
mssql stored procedure implicit return value support

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/SimpleStoredProc/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/SimpleStoredProc/content.txt
@@ -16,3 +16,8 @@ GO
 |paradajz|8|
 
 
+Caputure the implicit return value
+
+!|Execute Procedure|CalcLength_P|
+|name|str length?|?|
+|mika|4|0|


### PR DESCRIPTION
Add support for capturing procedure implicit return value (integer)

This is intended to resolve  #351