### PR TITLE
fix mssql proc params metadata query errors

### DIFF
--- a/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
+++ b/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
@@ -224,10 +224,10 @@ public class SqlServerEnvironment extends AbstractDbEnvironment {
                     + "   from sys.parameters p "
                     + "   union all select "
                     + "        '' as [name], 'int' as [Type], "
-                    + "        4 as max_length, 1 as [is_output], 0 as is_cursor_ref, "
-                    + "        null as parameter_id, 1 as set_id, o.object_id "
+                    + "        4 as max_length, 1 as is_output, 0 as is_cursor_ref, "
+                    + "        null as parameter_id, 1 as set_id, object_id "
                     + "   from sys.objects where type in (N'P', N'PC') "
-                    + ") where object_id = OBJECT_ID(?) order by set_id, parameter_id");
+                    + ") as u where object_id = OBJECT_ID(?) order by set_id, parameter_id");
     }
 
     public String buildInsertCommand(String tableName,


### PR DESCRIPTION
This is fixing syntax errors in mssql metadata query introduced by #352 

With this the basic case of #351 is working OK.

As per #351, it has been concluded that there is no need to address the subtle case when RAISEERROR is used to have both return value and error raised.