### PR TITLE
Enable hsql tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ The quickest way to get feedback on your code changes is to run the fast build:
 
     $ ./gradlew clean fastbuild
 
-This is a pure-Java build that runs the `core` unit tests and the Derby integration tests (with Derby running embedded).
+This is a pure-Java build that runs the `core` unit tests, the Derby integration tests (with Derby running embedded) and the HSQLDB integration tests (with HSQLDB running in-process, memory-only).
 
 #### Integration tests
 

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/SetUp/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/SetUp/content.txt
@@ -1,0 +1,7 @@
+|dbfit.HSQLDBTest|
+
+|Connect|jdbc:hsqldb:mem:dbfit|
+
+|Execute Ddl|CREATE TABLE users (name VARCHAR(20) NOT NULL, username VARCHAR(20) NOT NULL)|
+
+|Execute Ddl|CREATE PROCEDURE makeuser() MODIFIES SQL DATA insert into users (name,username) values ('user1','fromproc')|

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/SetUp/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/SetUp/properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit/>
+	<Files/>
+	<Properties/>
+	<RecentChanges/>
+	<Refactor/>
+	<Search/>
+	<Versions/>
+	<WhereUsed/>
+</properties>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/TearDown/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/TearDown/content.txt
@@ -1,0 +1,1 @@
+|Execute|SHUTDOWN|

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/TearDown/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/TearDown/properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit/>
+	<Files/>
+	<Properties/>
+	<RecentChanges/>
+	<Refactor/>
+	<Search/>
+	<Versions/>
+	<WhereUsed/>
+</properties>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/content.txt
@@ -1,0 +1,1 @@
+!contents -R2 -g -p -f -h

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/FlowMode/properties.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit/>
+	<Files/>
+	<Properties/>
+	<RecentChanges/>
+	<Refactor/>
+	<Search/>
+	<Suite/>
+	<SymbolicLinks>
+		<CoreTests>.DbFit.AcceptanceTests.CoreTests</CoreTests>
+	</SymbolicLinks>
+	<Versions/>
+	<WhereUsed/>
+</properties>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/content.txt
@@ -1,0 +1,1 @@
+!contents -R2 -g -p -f -h

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit/>
+	<Files/>
+	<Properties/>
+	<RecentChanges/>
+	<Refactor/>
+	<Search/>
+	<Suite/>
+	<Versions/>
+	<WhereUsed/>
+</properties>

--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ task starthere(type: Exec, dependsOn: [copyLocal, copyExtraLibs, copyConnections
     args '-d', '..', '-o', '-f', 'plugins.properties'
 }
 
-task fastbuild(dependsOn: [':dbfit-java:core:check', ':dbfit-java:derby:check'])
+task fastbuild(dependsOn: [':dbfit-java:core:check', ':dbfit-java:derby:check', ':dbfit-java:hsqldb:check'])
 
 def onWindows() {
     System.properties['os.name'].toLowerCase().contains('windows')

--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -112,6 +112,7 @@ project('hsqldb') {
 
     dependencies {
         compile project(':dbfit-java:core')
+        runtime 'org.hsqldb:hsqldb:2.3.2@jar'
     }
 }
 

--- a/dbfit-java/hsqldb/src/main/java/dbfit/environment/HSQLDBEnvironment.java
+++ b/dbfit-java/hsqldb/src/main/java/dbfit/environment/HSQLDBEnvironment.java
@@ -66,7 +66,7 @@ public class HSQLDBEnvironment extends AbstractDbEnvironment {
     public Map<String, DbParameterAccessor> getAllColumns(String tableOrViewName)
             throws SQLException {
         String qry = "SELECT COLUMN_NAME, TYPE_NAME FROM INFORMATION_SCHEMA.SYSTEM_COLUMNS\n"
-                + "WHERE TABLE_NAME= ?";
+                + "WHERE TABLE_NAME = ?";
         return readIntoParams(tableOrViewName, qry);
     }
 
@@ -74,8 +74,18 @@ public class HSQLDBEnvironment extends AbstractDbEnvironment {
             String tableOrViewName, String query) throws SQLException {
         checkConnectionValid(currentConnection);
         try (PreparedStatement dc = currentConnection.prepareStatement(query)) {
-            dc.setString(1, tableOrViewName);
 
+            String tvname;
+            if (tableOrViewName.trim().startsWith("\"") && tableOrViewName.trim().endsWith("\"")) {
+                // Remove double quotes.
+                tvname = tableOrViewName.replaceFirst("\"", "");
+                int i = tvname.lastIndexOf("\"");
+                tvname = tvname.substring(0, i) + tvname.substring(i + 1);
+            } else {
+                tvname = tableOrViewName.toUpperCase();
+            }
+
+            dc.setString(1, tvname);
             ResultSet rs = dc.executeQuery();
             Map<String, DbParameterAccessor> allParams = new HashMap<String, DbParameterAccessor>();
             int position = 0;

--- a/dbfit-java/hsqldb/src/test/java/dbfit/environment/HSQLDBEnvironmentFactoryTest.java
+++ b/dbfit-java/hsqldb/src/test/java/dbfit/environment/HSQLDBEnvironmentFactoryTest.java
@@ -2,12 +2,10 @@ package dbfit.environment;
 
 import dbfit.api.DBEnvironment;
 import org.junit.Test;
-import org.junit.Ignore;
 import static org.junit.Assert.*;
 
 public class HSQLDBEnvironmentFactoryTest {
 
-    @Ignore("HSQLDB driver not available during build")
     @Test
     public void newDbEnvironmentTest() throws Exception {
         DBEnvironment env = dbfit.api.DbEnvironmentFactory.newEnvironmentInstance("HSQLDB");

--- a/dbfit-java/hsqldb/src/test/java/dbfit/environment/HSQLDBRegressionTest.java
+++ b/dbfit-java/hsqldb/src/test/java/dbfit/environment/HSQLDBRegressionTest.java
@@ -1,0 +1,20 @@
+package dbfit.environment;
+
+import fitnesse.junit.FitNesseSuite;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static fitnesse.junit.FitNesseSuite.*;
+
+public class HSQLDBRegressionTest {
+
+    @RunWith(FitNesseSuite.class)
+    @Name("DbFit.AcceptanceTests.JavaTests.HsqlTests.FlowMode")
+    @FitnesseDir("../..")
+    @OutputDir("../../tmp")
+    public static class FlowModeTest {
+        @Test public void dummy(){}
+    }
+
+}


### PR DESCRIPTION
This introduces the CoreTests for HSQL.

It also allows mixed case table names to be accessed by Insert/Update/Clean as HSQL converts unquoted names to upper case upon creation.

Tests are executed against a memory-only database to make set-up simpler but this might be better to start up a database as part of the VM provisioning so that the DDL for the CoreTests can be moved out of the SetUp.

``hsqldb-2.3.2.jar`` is currently being pulled from ``custom_libs``.