### PR TITLE
Add missing DB2 Express C dependency (installer warning)

### DIFF
--- a/test_vm/vendor/cookbooks/dbfit_test/recipes/db2.rb
+++ b/test_vm/vendor/cookbooks/dbfit_test/recipes/db2.rb
@@ -5,6 +5,7 @@ package "libaio"
 # So we use:
 yum_package "pam.i686"
 package "numactl"
+package "libstdc++.i686"
 
 execute 'install DB2 package if available' do
   project_root = node['dbfit']['project_root']


### PR DESCRIPTION
This update installs libstdc++.so.6. It's absence is warned by the DB2 Express-C installer.