### PR TITLE
Support case sensitive collation object names in SQL Server

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithReturning/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithReturning/content.txt
@@ -17,7 +17,7 @@
 
 |set parameter|userid|<<zeka|
 
-|Query|Select * from Users where userid=@userid|
+|Query|Select * from Users where !-UserId-!=@userid|
 |username|name|userid|
 |Zeka|Dusko Dugousko|<<zeka|
 

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithReturning/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithReturning/properties.xml
@@ -2,7 +2,6 @@
 <properties>
 	<Edit/>
 	<Files/>
-	<LastModified>20071022152525</LastModified>
 	<Properties/>
 	<RecentChanges/>
 	<Refactor/>

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithSchemaName/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithSchemaName/content.txt
@@ -12,5 +12,20 @@
 |nuja|2|
 |nnn|3|
 
-
 |Execute|Drop table dbo.Test_DBFit|
+
+|Execute|Create table FitNesseTestDB.dbo.Test_DBFit(name varchar(50), luckyNumber int)|
+
+|Insert|FitNesseTestDB.dbo.Test_DBFit|
+|name|luckyNumber|
+|pera|1|
+|nuja|2|
+|nnn|3|
+
+|Query|Select * from FitNesseTestDB.dbo.Test_DBFit|
+|name|lucky Number|
+|pera|1|
+|nuja|2|
+|nnn|3|
+
+|Execute|Drop table FitNesseTestDB.dbo.Test_DBFit|

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithSchemaName/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithSchemaName/properties.xml
@@ -2,12 +2,10 @@
 <properties>
 	<Edit/>
 	<Files/>
-	<LastModified>20080109214659</LastModified>
 	<Properties/>
 	<RecentChanges/>
 	<Refactor/>
 	<Search/>
-	<Suites></Suites>
 	<Test/>
 	<Versions/>
 	<WhereUsed/>

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/InspectTests/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/InspectTests/content.txt
@@ -4,13 +4,13 @@
 
 !3 Inspect Table prints table/view columns to be used for Insert/Update/Query procedure
  
-!|Inspect Table|users|
+!|Inspect Table|Users|
 
 !3 Inspect query prints columns and data
 
-|Insert|users|
+|Insert|Users|
 |name|username|
 |david haselhoff|dhoff|
 |arthur dent|adent|
 
-!|Inspect query|select * from users|
+!|Inspect query|select * from Users|

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/InspectTests/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/InspectTests/properties.xml
@@ -2,12 +2,10 @@
 <properties>
 	<Edit/>
 	<Files/>
-	<LastModified>20071126060054</LastModified>
 	<Properties/>
 	<RecentChanges/>
 	<Refactor/>
 	<Search/>
-	<Suites></Suites>
 	<Test/>
 	<Versions/>
 	<WhereUsed/>

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/ParametersAreLoadedAutomaticallyFromVariables/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/ParametersAreLoadedAutomaticallyFromVariables/content.txt
@@ -8,6 +8,6 @@ Parameters are loaded automatically from variables, no need to set them explicit
 |DevNull|null|>>nll|
 
 
-|Query|Select * from Users where userid=@pera|
-|username|name|userid|
+|Query|Select * from Users where !-UserId-!=@pera|
+|UserName|Name|UserId|
 |pera|Petar Detlic|<<pera|

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/ParametersAreLoadedAutomaticallyFromVariables/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/ParametersAreLoadedAutomaticallyFromVariables/properties.xml
@@ -2,7 +2,6 @@
 <properties>
 	<Edit/>
 	<Files/>
-	<LastModified>20070228164017</LastModified>
 	<Properties/>
 	<RecentChanges/>
 	<Refactor/>

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/StoredProcReturningQuery/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/StoredProcReturningQuery/content.txt
@@ -1,7 +1,7 @@
 !3 if a stored proc opens a cursor, it can be directly queried
 
-|insert|users|
-|name|username|
+|insert|Users|
+|Name|!-UserName-!|
 |user1|user name 1|
 |user2|user name 2|
 |user3|user name 3|
@@ -11,8 +11,8 @@
 |user7|user name 7|
 
 
-|query|listusers_p 3|
-|name|username|
+|query|ListUsers_P 3|
+|Name|!-UserName-!|
 |user1|user name 1|
 |user2|user name 2|
 |user3|user name 3|
@@ -21,8 +21,8 @@ If you use a parameter, make sure to include exec
 
 |set parameter|hm|3|
 
-|query|exec listusers_p @hm|
-|name|username|
+|query|exec ListUsers_P @hm|
+|Name|UserName|
 |user1|user name 1|
 |user2|user name 2|
 |user3|user name 3|

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/StoredProcReturningQuery/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/StoredProcReturningQuery/properties.xml
@@ -2,12 +2,10 @@
 <properties>
 	<Edit/>
 	<Files/>
-	<LastModified>20080115075759</LastModified>
 	<Properties/>
 	<RecentChanges/>
 	<Refactor/>
 	<Search/>
-	<Suites/>
 	<Test/>
 	<Versions/>
 	<WhereUsed/>

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/UpdateTest/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/UpdateTest/content.txt
@@ -1,30 +1,30 @@
 !3 Update table handles the update command - specify fields to be updated with = on the end.
 
-|execute|delete from users|
+|execute|delete from Users|
 
-|insert|users|
+|insert|Users|
 |name|username|
 |arthur dent|adent|
 |ford prefect|fpref|
 |zaphod beeblebrox|zaphod|
 
-|update|users|
-|username=|name|
+|update|Users|
+|UserName=|name|
 |adent2|arthur dent|
 
-|query|select * from users|
-|name|username|
+|query|select * from Users|
+|Name|!-UserName-!|
 |arthur dent|adent2|
 |ford prefect|fpref|
 |zaphod beeblebrox|zaphod|
 
 !3 same column can be used in the selection and update part
 
-|update|users|
+|update|Users|
 |username=|username|
 |adent3|adent2|
 
-|query|select * from users|
+|query|select * from Users|
 |name|username|
 |arthur dent|adent3|
 |ford prefect|fpref|
@@ -32,29 +32,29 @@
 
 !3 symbols work with update part
 
-|query|select * from users|
-|name|username|userid?|
+|query|select * from Users|
+|Name|UserName|UserId?|
 |arthur dent|adent3|>>ad|
 |ford prefect|fpref|>>fp|
 |zaphod beeblebrox|zaphod|>>z|
 
-|update|users|
-|username=|userid|
+|update|Users|
+|!-UserName-!=|!-UserId-!|
 |adent4|<<ad|
 
-|query|select * from users|
-|name|username|
+|query|select * from Users|
+|Name|!-UserName-!|
 |arthur dent|adent4|
 |ford prefect|fpref|
 |zaphod beeblebrox|zaphod|
 
 !3 multiple columns on the update side
 
-|update|users|
+|update|Users|
 |name=|username=|userid|
 |ford prefect|fpref2|<<ad|
 
-|query|select * from users|
+|query|select * from Users|
 |name|username|
 |ford prefect|fpref2|
 |ford prefect|fpref|
@@ -63,11 +63,11 @@
 
 !3 multiple columns on the select side
 
-|update|users|
+|update|Users|
 |name=|username=|name|userid|
 |john travolta|jtrav|ford prefect|<<ad|
 
-|query|select * from users|
+|query|select * from Users|
 |name|username|
 |john travolta|jtrav|
 |ford prefect|fpref|

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/UpdateTest/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/UpdateTest/properties.xml
@@ -2,12 +2,10 @@
 <properties>
 	<Edit/>
 	<Files/>
-	<LastModified>20071013164513</LastModified>
 	<Properties/>
 	<RecentChanges/>
 	<Refactor/>
 	<Search/>
-	<Suites></Suites>
 	<Test/>
 	<Versions/>
 	<WhereUsed/>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/SqlServerTests/FlowMode/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/SqlServerTests/FlowMode/properties.xml
@@ -7,37 +7,36 @@
 	<Refactor/>
 	<Search/>
 	<Suite/>
-	<Suites/>
 	<SymbolicLinks>
-		<NullValueAcceptedAsParameter>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.NullValueAcceptedAsParameter</NullValueAcceptedAsParameter>
-		<QueryWithParameter>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.QueryWithParameter</QueryWithParameter>
-		<ParametersAreLoadedAutomaticallyFromVariables>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ParametersAreLoadedAutomaticallyFromVariables</ParametersAreLoadedAutomaticallyFromVariables>
 		<BulkInsert>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsert</BulkInsert>
-		<SimpleSelect>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.SimpleSelect</SimpleSelect>
-		<StoredProcedureWithException>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.StoredProcedureWithException</StoredProcedureWithException>
-		<SequenceSelect>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.SequenceSelect</SequenceSelect>
-		<InOutParams>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.InOutParams</InOutParams>
-		<UpdateTest>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.UpdateTest</UpdateTest>
-		<SimpleStoredProc>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.SimpleStoredProc</SimpleStoredProc>
-		<DataTypes>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.DataTypes</DataTypes>
-		<ExpectingErrors>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ExpectingErrors</ExpectingErrors>
-		<OrderedQuery>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.OrderedQuery</OrderedQuery>
-		<ColumnMatching>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ColumnMatching</ColumnMatching>
-		<ExecutingStatements>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ExecutingStatements</ExecutingStatements>
-		<MultiLineQueries>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.MultiLineQueries</MultiLineQueries>
-		<InspectTests>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.InspectTests</InspectTests>
-		<ParametersArePersistent>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ParametersArePersistent</ParametersArePersistent>
-		<ReadingQueryIntoVariables>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ReadingQueryIntoVariables</ReadingQueryIntoVariables>
-		<StoreAndCompareQueries>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.StoreAndCompareQueries</StoreAndCompareQueries>
-		<BulkInsertWithSchemaName>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsertWithSchemaName</BulkInsertWithSchemaName>
-		<StoredProcReturningQuery>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.StoredProcReturningQuery</StoredProcReturningQuery>
-		<CommonSuite>.DbFit.AcceptanceTests.CoreTests.CommonSuite</CommonSuite>
-		<TransactionsTest>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.TransactionsTest</TransactionsTest>
-		<QueryStored>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.QueryStored</QueryStored>
 		<BulkInsertWithReturning>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsertWithReturning</BulkInsertWithReturning>
-		<CallingFunctions>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.CallingFunctions</CallingFunctions>
-		<UnknownParametersAreIgnored>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.UnknownParametersAreIgnored</UnknownParametersAreIgnored>
+		<BulkInsertWithSchemaName>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsertWithSchemaName</BulkInsertWithSchemaName>
 		<BulkInsertWithWeirdColumnNames>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsertWithWeirdColumnNames</BulkInsertWithWeirdColumnNames>
+		<CallingFunctions>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.CallingFunctions</CallingFunctions>
+		<ColumnMatching>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ColumnMatching</ColumnMatching>
+		<CommonSuite>.DbFit.AcceptanceTests.CoreTests.CommonSuite</CommonSuite>
+		<DataTypes>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.DataTypes</DataTypes>
+		<ExecutingStatements>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ExecutingStatements</ExecutingStatements>
+		<ExpectingErrors>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ExpectingErrors</ExpectingErrors>
+		<InOutParams>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.InOutParams</InOutParams>
+		<InspectTests>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.InspectTests</InspectTests>
+		<MultiLineQueries>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.MultiLineQueries</MultiLineQueries>
+		<NullValueAcceptedAsParameter>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.NullValueAcceptedAsParameter</NullValueAcceptedAsParameter>
+		<OrderedQuery>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.OrderedQuery</OrderedQuery>
+		<ParametersAreLoadedAutomaticallyFromVariables>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ParametersAreLoadedAutomaticallyFromVariables</ParametersAreLoadedAutomaticallyFromVariables>
+		<ParametersArePersistent>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ParametersArePersistent</ParametersArePersistent>
+		<QueryStored>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.QueryStored</QueryStored>
+		<QueryWithParameter>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.QueryWithParameter</QueryWithParameter>
+		<ReadingQueryIntoVariables>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ReadingQueryIntoVariables</ReadingQueryIntoVariables>
+		<SequenceSelect>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.SequenceSelect</SequenceSelect>
+		<SimpleSelect>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.SimpleSelect</SimpleSelect>
+		<SimpleStoredProc>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.SimpleStoredProc</SimpleStoredProc>
+		<StoreAndCompareQueries>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.StoreAndCompareQueries</StoreAndCompareQueries>
+		<StoredProcReturningQuery>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.StoredProcReturningQuery</StoredProcReturningQuery>
+		<StoredProcedureWithException>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.StoredProcedureWithException</StoredProcedureWithException>
+		<TransactionsTest>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.TransactionsTest</TransactionsTest>
+		<UnknownParametersAreIgnored>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.UnknownParametersAreIgnored</UnknownParametersAreIgnored>
+		<UpdateTest>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.UpdateTest</UpdateTest>
 	</SymbolicLinks>
 	<Versions/>
 	<WhereUsed/>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/SqlServerTests/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/SqlServerTests/properties.xml
@@ -2,13 +2,14 @@
 <properties>
 	<Edit/>
 	<Files/>
-	<LastModified>20080330043718</LastModified>
 	<Properties/>
 	<RecentChanges/>
 	<Refactor/>
 	<Search/>
 	<Suite/>
-	<Suites/>
+	<SymbolicLinks>
+		<DisabledTests>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.DisabledTests</DisabledTests>
+	</SymbolicLinks>
 	<Versions/>
 	<WhereUsed/>
 	<saveId>1206796425000</saveId>

--- a/dbfit-java/core/src/main/java/dbfit/util/LangUtils.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/LangUtils.java
@@ -13,12 +13,22 @@ public class LangUtils {
     }
 
     public static String join(List<String> list, String separator) {
+        return enquoteAndJoin(list, separator, "", "");
+    }
+
+    public static String enquoteAndJoin(Iterable<String> list,
+            String separator, String prefix, String suffix) {
         StringBuilder s = new StringBuilder();
-        for (int i = 0; i < list.size(); i++) {
-            s.append(list.get(i));
-            if (i < list.size() - 1)
-                s.append(separator);
-        };
+        String sep = "";
+        for (String item: list) {
+            s.append(sep).append(prefix).append(item).append(suffix);
+            sep = separator;
+        }
         return s.toString();
+    }
+
+    public static String enquoteAndJoin(String[] list,
+            String separator, String prefix, String suffix) {
+        return enquoteAndJoin(java.util.Arrays.asList(list), separator, prefix, suffix);
     }
 }

--- a/dbfit-java/core/src/test/java/dbfit/util/LangUtilsTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/LangUtilsTest.java
@@ -13,4 +13,8 @@ public class LangUtilsTest {
     @Test public void join() {
         assertEquals("A,B,C", LangUtils.join(asList("A", "B", "C"), ","));
     }
+
+    @Test public void enquoteAndJoin() {
+        assertEquals("[A].[B].[C]", LangUtils.enquoteAndJoin(asList("A", "B", "C"), ".", "[", "]"));
+    }
 }

--- a/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
+++ b/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
@@ -6,6 +6,7 @@ import dbfit.util.DbParameterAccessor;
 import dbfit.util.DbParameterAccessorsMapBuilder;
 import dbfit.util.Direction;
 import static dbfit.util.Direction.*;
+import static dbfit.util.LangUtils.enquoteAndJoin;
 import dbfit.util.TypeNormaliserFactory;
 import static dbfit.environment.SqlServerTypeNameNormaliser.normaliseTypeName;
 
@@ -79,16 +80,10 @@ public class SqlServerEnvironment extends AbstractDbEnvironment {
         DbParameterAccessorsMapBuilder params = new DbParameterAccessorsMapBuilder();
 
         objname = objname.replaceAll("[^a-zA-Z0-9_.#]", "");
-        String[] qualifiers = objname.split("\\.");
-        StringBuilder bracketedName = new StringBuilder();
-        String separator = "";
-        for (int i = 0; i < qualifiers.length; i++) {
-            bracketedName.append(separator + "[" + qualifiers[i] + "]");
-            separator = ".";
-        }
+        String bracketedName = enquoteAndJoin(objname.split("\\."), ".", "[", "]");
 
         try (PreparedStatement dc = currentConnection.prepareStatement(query)) {
-            dc.setString(1, bracketedName.toString());
+            dc.setString(1, bracketedName);
             ResultSet rs = dc.executeQuery();
 
             while (rs.next()) {

--- a/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
+++ b/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
@@ -6,7 +6,6 @@ import dbfit.util.DbParameterAccessor;
 import dbfit.util.DbParameterAccessorsMapBuilder;
 import dbfit.util.Direction;
 import static dbfit.util.Direction.*;
-import static dbfit.util.NameNormaliser.normaliseName;
 import dbfit.util.TypeNormaliserFactory;
 import static dbfit.environment.SqlServerTypeNameNormaliser.normaliseTypeName;
 
@@ -15,7 +14,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -80,15 +78,17 @@ public class SqlServerEnvironment extends AbstractDbEnvironment {
             String query) throws SQLException {
         DbParameterAccessorsMapBuilder params = new DbParameterAccessorsMapBuilder();
 
-        if (objname.contains(".")) {
-            String[] schemaAndName = objname.split("[\\.]", 2);
-            objname = "[" + schemaAndName[0] + "].[" + schemaAndName[1] + "]";
-        } else {
-            objname = "[" + normaliseName(objname) + "]";
+        objname = objname.replaceAll("[^a-zA-Z0-9_.#]", "");
+        String[] qualifiers = objname.split("\\.");
+        StringBuilder bracketedName = new StringBuilder();
+        String separator = "";
+        for (int i = 0; i < qualifiers.length; i++) {
+            bracketedName.append(separator + "[" + qualifiers[i] + "]");
+            separator = ".";
         }
 
         try (PreparedStatement dc = currentConnection.prepareStatement(query)) {
-            dc.setString(1, normaliseName(objname));
+            dc.setString(1, bracketedName.toString());
             ResultSet rs = dc.executeQuery();
 
             while (rs.next()) {
@@ -125,7 +125,7 @@ public class SqlServerEnvironment extends AbstractDbEnvironment {
     private static List<String> decimalTypes = Arrays.asList(new String[] {
             "DECIMAL", "MONEY", "SMALLMONEY" });
     private static List<String> timestampTypes = Arrays.asList(new String[] {
-            "SMALLDATETIME", "DATETIME", "DATETIME2", "TIMESTAMP" });
+            "SMALLDATETIME", "DATETIME", "DATETIME2" });
     private static List<String> dateTypes = Arrays.asList("DATE");
     private static List<String> timeTypes = Arrays.asList("TIME");
 
@@ -134,7 +134,7 @@ public class SqlServerEnvironment extends AbstractDbEnvironment {
     // private static List<String> doubleTypes=Arrays.asList(new
     // String[]{"DOUBLE"});
 
-    // private static string[] BinaryTypes=new string[] {"BINARY","VARBINARY"};
+    // private static string[] BinaryTypes=new string[] {"BINARY","VARBINARY", "TIMESTAMP"};
     // private static string[] GuidTypes = new string[] { "UNIQUEIDENTIFIER" };
     // private static string[] VariantTypes = new string[] { "SQL_VARIANT" };
 

--- a/dbfit-java/sqlserver/src/test/java/dbfit/environment/SqlServerRegressionTest.java
+++ b/dbfit-java/sqlserver/src/test/java/dbfit/environment/SqlServerRegressionTest.java
@@ -16,13 +16,4 @@ public class SqlServerRegressionTest {
     public static class FlowModeTest {
         @Test public void dummy(){}
     }
-
-    @RunWith(FitNesseRunner.class)
-    @Suite("DbFit.AcceptanceTests.JavaTests.SqlServerTests.StandaloneFixtures")
-    @FitnesseDir("../..")
-    @OutputDir("../../tmp")
-    @Ignore
-    public static class StandaloneFixturesTest {
-        @Test public void dummy(){}
-    }
 }

--- a/dbfit-java/sqlserver/src/test/resources/acceptancescripts-SqlServer.sql
+++ b/dbfit-java/sqlserver/src/test/resources/acceptancescripts-SqlServer.sql
@@ -1,13 +1,43 @@
+USE [master]
+GO
+
+CREATE DATABASE [FitNesseTestDB]
+GO
+
+/* Case sensitive collation - for additional required precision for testing */
+ALTER DATABASE [FitNesseTestDB] COLLATE Latin1_General_CS_AS
+/* Case insensitive collation
+ALTER DATABASE [FitNesseTestDB] COLLATE Latin1_General_CI_AS */
+GO
+
+CREATE LOGIN [FitNesseUser] WITH PASSWORD='FitNesseUser'
+GO
+
+USE [FitNesseTestDB]
+GO
+
+CREATE USER [FitNesseUser] FOR LOGIN [FitNesseUser] WITH DEFAULT_SCHEMA=[dbo]
+GO
+
+ALTER ROLE [db_owner] ADD MEMBER [FitNesseUser]
+GO
+
+ALTER DATABASE [FitNesseTestDB] SET  READ_WRITE
+GO
+
+
+
+
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
 IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[Multiply]') AND type in (N'FN', N'IF', N'TF', N'FS', N'FT'))
 BEGIN
-execute dbo.sp_executesql @statement = N'  create function [dbo].[Multiply](@n1 int, @n2 int) returns int as  begin  	declare @num3 int;  	set @num3 = @n1*@n2;  	return @num3;  end;  ' 
+execute dbo.sp_executesql @statement = N'  create function [dbo].[Multiply](@n1 int, @n2 int) returns int as  begin  	declare @num3 int;  	set @num3 = @n1*@n2;  	return @num3;  end;  '
 END
-
 GO
+
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -21,9 +51,10 @@ AS
 BEGIN
 	SET @strlength = DataLength(@name);
 END;
-' 
+'
 END
 GO
+
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -39,11 +70,11 @@ CREATE FUNCTION [dbo].[ReturnUserTable_F]
 (
 	@howmuch int
 )
-RETURNS 
-@userTable TABLE 
+RETURNS
+@userTable TABLE
 (
 	-- Add the column definitions for the TABLE variable here
-	[user] varchar(50), 
+	[user] varchar(50),
 	[username] varchar(255)
 )
 AS
@@ -57,13 +88,13 @@ BEGIN
 		INSERT @userTable([user], [username])
 			VALUES(''User '' + CAST(@i AS VARCHAR(10)), ''Username '' + CAST(@i AS VARCHAR(10)))
 	END
-	
-	RETURN 
-END
-' 
-END
 
+	RETURN
+END
+'
+END
 GO
+
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -79,9 +110,10 @@ AS
 BEGIN
 	SET @concatenated = @firstString + '' '' + @secondString
 END
-' 
+'
 END
 GO
+
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -101,10 +133,10 @@ BEGIN
 	SET @concatenated = @firstString + '' '' + @secondString
 	RETURN @concatenated
 END
-' 
+'
 END
-
 GO
+
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -112,12 +144,13 @@ GO
 IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[Users]') AND type in (N'U'))
 BEGIN
 CREATE TABLE [dbo].[Users](
-	[name] [varchar](50) NULL,
-	[username] [varchar](50) NULL,
-	[userid] [int] IDENTITY(1,1) NOT NULL
+	[Name] [varchar](50) NULL,
+	[UserName] [varchar](50) NULL,
+	[UserId] [int] IDENTITY(1,1) NOT NULL
 ) ON [PRIMARY]
 END
 GO
+
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -134,13 +167,14 @@ BEGIN
 	WHILE (@i < @howmuch)
 	BEGIN
 		SET @i = @i + 1
-		INSERT [Users]([name], [username])
+		INSERT [Users]([Name], [UserName])
 			VALUES(''User '' + CAST(@i AS VARCHAR(10)), ''Username '' + CAST(@i AS VARCHAR(10)))
 	END
 END
-' 
+'
 END
 GO
+
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -153,14 +187,15 @@ EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [dbo].[OpenCrsr_P]
 AS
 BEGIN
 	SET @OutCrsr = CURSOR FOR
-	SELECT TOP (@howmuch) [name], [username], [userid]
+	SELECT TOP (@howmuch) [Name], [UserName], [UserId]
 	FROM [Users];
 
 	OPEN @OutCrsr;
 END
-' 
+'
 END
 GO
+
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -170,8 +205,9 @@ BEGIN
 EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [dbo].[DeleteUserTable_P]
 AS
 DELETE [Users];
-' 
+'
 END
+GO
 
 CREATE PROCEDURE [dbo].[TestProc2]
 	@iddocument int,
@@ -187,18 +223,21 @@ begin
 	raiserror(@errorsave, 15, 1, 'Custom error message')
 	return @errorsave
 end
+GO
 
-sp_addmessage @msgnum = 53120, @severity=1, @msgtext = 'test user defined error msg' 
+sp_addmessage @msgnum = 53120, @severity=1, @msgtext = 'test user defined error msg'
 
 CREATE procedure [dbo].[ListUsers_P] @howmuch int AS
 BEGIN
-select top (@howmuch) * from users order by userid
+select top (@howmuch) * from Users order by UserId
 END;
+GO
 
 create procedure MultiplyIO(@factor int, @val int output) as
 begin
 	set @val = @factor*@val;
 end;
+GO
 
 create procedure TestDecimal
 @inParam decimal(15, 8),
@@ -209,3 +248,10 @@ begin
 set @copyOfInParam = @inParam
 set @constOutParam = 123.456;
 end
+GO
+
+create procedure [dbo].[MakeUser] AS
+begin
+	insert into Users (Name, UserName) values ('user1', 'fromproc');
+end
+GO

--- a/dbfit-java/sqlserver/src/test/resources/acceptancescripts-SqlServer2000.sql
+++ b/dbfit-java/sqlserver/src/test/resources/acceptancescripts-SqlServer2000.sql
@@ -4,7 +4,7 @@ SET QUOTED_IDENTIFIER ON
 GO
 IF NOT EXISTS (SELECT * FROM sysobjects WHERE id = OBJECT_ID(N'[dbo].[Multiply]') AND type in (N'FN', N'IF', N'TF', N'FS', N'FT'))
 BEGIN
-execute dbo.sp_executesql @statement = N'  create function [dbo].[Multiply](@n1 int, @n2 int) returns int as  begin  	declare @num3 int;  	set @num3 = @n1*@n2;  	return @num3;  end  ' 
+execute dbo.sp_executesql @statement = N'  create function [dbo].[Multiply](@n1 int, @n2 int) returns int as  begin  	declare @num3 int;  	set @num3 = @n1*@n2;  	return @num3;  end  '
 END
 GO
 
@@ -20,7 +20,7 @@ AS
 BEGIN
 	SET @strlength = DataLength(@name);
 END
-' 
+'
 END
 GO
 
@@ -40,11 +40,11 @@ CREATE FUNCTION [dbo].[ReturnUserTable_F]
 (
 	@howmuch int
 )
-RETURNS 
-@userTable TABLE 
+RETURNS
+@userTable TABLE
 (
 	-- Add the column definitions for the TABLE variable here
-	[user] varchar(50), 
+	[user] varchar(50),
 	[username] varchar(255)
 )
 AS
@@ -58,10 +58,10 @@ BEGIN
 		INSERT @userTable([user], [username])
 			VALUES(''User '' + CAST(@i AS VARCHAR(10)), ''Username '' + CAST(@i AS VARCHAR(10)))
 	END
-	
-	RETURN 
+
+	RETURN
 END
-' 
+'
 END
 GO
 
@@ -81,7 +81,7 @@ AS
 BEGIN
 	SET @concatenated = @firstString + '' '' + @secondString
 END
-' 
+'
 END
 GO
 
@@ -104,7 +104,7 @@ BEGIN
 	SET @concatenated = @firstString + '' '' + @secondString
 	RETURN @concatenated
 END
-' 
+'
 END
 
 
@@ -146,7 +146,7 @@ BEGIN
 			VALUES(''User '' + CAST(@i AS VARCHAR(10)), ''Username '' + CAST(@i AS VARCHAR(10)))
 	END
 END
-' 
+'
 END
 GO
 
@@ -159,7 +159,7 @@ BEGIN
 EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [dbo].[DeleteUserTable_P]
 AS
 DELETE [Users];
-' 
+'
 END
 GO
 
@@ -186,7 +186,7 @@ end
 GO
 
 --User needs to have permission to perform this action.
-sp_addmessage @msgnum = 53120, @severity=1, @msgtext = 'test user defined error msg' 
+sp_addmessage @msgnum = 53120, @severity=1, @msgtext = 'test user defined error msg'
 GO
 
 --drop procedure [dbo].[TestProc2]
@@ -203,7 +203,7 @@ GO
 --GO
 --drop function [dbo].[ReturnUserTable_F]
 --GO
---drop procedure [dbo].[CalcLength_P] 
+--drop procedure [dbo].[CalcLength_P]
 --GO
 --drop function [dbo].[Multiply]
 --GO
@@ -217,3 +217,9 @@ begin
 set @copyOfInParam = @inParam
 set @constOutParam = 123.456;
 end
+
+create procedure [dbo].[MakeUser] AS
+begin
+	insert into Users (Name, UserName) values ('user1', 'fromproc');
+end
+GO


### PR DESCRIPTION
Support case sensitive/insensitive collations.
Remove redundant StandAlone mode regression test call.
Tidy and complete DB setup scripts.
Support 3 part table/view/procedure names.