### PR TITLE
Forward default FitNesse port to allow FitNesse acccess from host

### DIFF
--- a/test_vm/Vagrantfile
+++ b/test_vm/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "chef/centos-6.6"
   config.vm.host_name = "dbfitvm"
   config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "forwarded_port", guest: 8085, host: 8085
   config.vm.synced_folder "..", "/var/dbfit", CONFIG['synced_folder_options']
 
   config.vm.provision :chef_solo do |chef|


### PR DESCRIPTION
This PR is to allow host access to the FitNesse server running on the guest test VM.

I have had to add port fowarding to Vagrantfile in every previous test VM I've built hence I'm proposing this is added permanently.