### PR TITLE
Use CoreTests suite for HSQLDB Standalone mode tests

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/SetUp/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/SetUp/content.txt
@@ -1,5 +1,7 @@
-|dbfit.HSQLDBTest|
+|Import Fixture|
+|dbfit.fixture|
 
+|Database Environment|HSQLDB|
 |Connect|jdbc:hsqldb:mem:dbfit|
 
 |Execute Ddl|${CREATEUSERTABLE}|

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/SetUp/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/SetUp/properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/TearDown/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/TearDown/content.txt
@@ -1,0 +1,1 @@
+|Execute|SHUTDOWN|

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/TearDown/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/TearDown/content.txt
@@ -1,1 +1,4 @@
 |Execute|SHUTDOWN|
+
+!|dbfit.util.ExportFixture|
+|dbfit.fixture|

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/TearDown/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/TearDown/properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/content.txt
@@ -1,0 +1,1 @@
+!contents -R2 -g -p -f -h

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/StandaloneFixtures/properties.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Suite/>
+<SymbolicLinks>
+<CoreTests>.DbFit.AcceptanceTests.CoreTests</CoreTests>
+</SymbolicLinks>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/HsqlTests/content.txt
@@ -1,1 +1,4 @@
+!define CREATEUSERTABLE {CREATE TABLE users (name VARCHAR(20) NOT NULL, username VARCHAR(20) NOT NULL)}
+!define CREATEMAKEUSERPROC {CREATE PROCEDURE makeuser() MODIFIES SQL DATA INSERT INTO users (name, username) VALUES ('user1', 'fromproc')}
+
 !contents -R2 -g -p -f -h

--- a/dbfit-java/hsqldb/src/integration-test/java/dbfit/environment/HSQLDBRegressionTest.java
+++ b/dbfit-java/hsqldb/src/integration-test/java/dbfit/environment/HSQLDBRegressionTest.java
@@ -14,7 +14,18 @@ public class HSQLDBRegressionTest {
     @FitnesseDir("../..")
     @OutputDir("../../tmp")
     public static class FlowModeTest {
-        @Test public void dummy(){}
+        @Test
+        public void dummy() {
+        }
     }
 
+    @RunWith(FitNesseRunner.class)
+    @Suite("DbFit.AcceptanceTests.JavaTests.HsqlTests.StandaloneFixtures")
+    @FitnesseDir("../..")
+    @OutputDir("../../tmp")
+    public static class StandaloneFixturesTest {
+        @Test
+        public void dummy() {
+        }
+    }
 }


### PR DESCRIPTION
Enhance test coverage for HSQLDB by introducing use of the `CoreTests` suite.