### PR TITLE
Support dollar characters in SQL Server object names

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithWeirdColumnNames/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithWeirdColumnNames/content.txt
@@ -1,16 +1,16 @@
-|Execute|Create table Test_DBFit(name varchar(50), [lucky Number] int)|
+|Execute|Create table Test_DBFit(na$me$ varchar(50), [lucky Number] int)|
 
 |Insert|Test_DBFit|
-|name|lucky Number|
+|na$me$|lucky Number|
 |pera|1|
 
 |Insert|Test_DBFit|
-|name|[lucky Number]|
+|na$me$|[lucky Number]|
 |nuja|2|
 |nnn|3|
 
 |Query|Select * from Test_DBFit|
-|name|lucky Number|
+|na$me$|lucky Number|
 |pera|1|
 |nuja|2|
 |nnn|3|

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithWeirdTableNames/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithWeirdTableNames/content.txt
@@ -1,0 +1,18 @@
+|Execute|Create table Test_$DBFit$(name varchar(50), [lucky Number] int)|
+
+|Insert|Test_$DBFit$|
+|name|lucky Number|
+|pera|1|
+
+|Insert|Test_$DBFit$|
+|name|[lucky Number]|
+|nuja|2|
+|nnn|3|
+
+|Query|Select * from Test_$DBFit$|
+|name|lucky Number|
+|pera|1|
+|nuja|2|
+|nnn|3|
+
+|Execute|Drop table Test_$DBFit$|

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithWeirdTableNames/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/BulkInsertWithWeirdTableNames/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Test/>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/SqlServerTests/FlowMode/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/SqlServerTests/FlowMode/properties.xml
@@ -12,6 +12,7 @@
 <BulkInsertWithReturning>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsertWithReturning</BulkInsertWithReturning>
 <BulkInsertWithSchemaName>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsertWithSchemaName</BulkInsertWithSchemaName>
 <BulkInsertWithWeirdColumnNames>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsertWithWeirdColumnNames</BulkInsertWithWeirdColumnNames>
+<BulkInsertWithWeirdTableNames>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsertWithWeirdTableNames</BulkInsertWithWeirdTableNames>
 <CallingFunctions>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.CallingFunctions</CallingFunctions>
 <ColumnMatching>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.ColumnMatching</ColumnMatching>
 <CoreTests>.DbFit.AcceptanceTests.CoreTests</CoreTests>

--- a/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
+++ b/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
@@ -79,7 +79,7 @@ public class SqlServerEnvironment extends AbstractDbEnvironment {
             String query) throws SQLException {
         DbParameterAccessorsMapBuilder params = new DbParameterAccessorsMapBuilder();
 
-        objname = objname.replaceAll("[^a-zA-Z0-9_.#]", "");
+        objname = objname.replaceAll("[^a-zA-Z0-9_.#$]", "");
         String bracketedName = enquoteAndJoin(objname.split("\\."), ".", "[", "]");
 
         try (PreparedStatement dc = currentConnection.prepareStatement(query)) {


### PR DESCRIPTION
Support the use of "$" characters in SQL Server table names (i.e. don't clean them before querying the dictionary views).

Also upgrade existing column name tests to ensure that "$" characters are supported in column names.
