### PR TITLE
Support access to DB objects in connection's non default DB

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/AccessObjectsInNonDefaultDb/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/AccessObjectsInNonDefaultDb/content.txt
@@ -1,0 +1,27 @@
+|Execute Ddl|Create table FitNesseTestDB2.dbo.Test_DBFit2 (name varchar(50), luckyNumber int)|
+
+|Insert|FitNesseTestDB2.dbo.Test_DBFit2|
+|name|luckyNumber|
+|Darth Maul|3|
+
+|Update|FitNesseTestDB2.dbo.Test_DBFit2|
+|name|luckyNumber=|
+|Darth Maul|666|
+
+|Query|Select * from FitNesseTestDB2.dbo.Test_DBFit2|
+|name|luckyNumber|
+|Darth Maul|666|
+
+|Clean|
+|table|clean?|
+|FitNesseTestDB2.dbo.Test_DBFit2|true|
+
+|Query|Select Count(*) as c from FitNesseTestDB2.dbo.Test_DBFit2|
+|c|
+|0|
+
+|Execute Procedure|FitNesseTestDB2.dbo.MakeUser2|
+
+|Query|Select * from FitNesseTestDB2.dbo.Users2|
+|Name|!-UserName-!|
+|user1|fromproc|

--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/AccessObjectsInNonDefaultDb/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/AccessObjectsInNonDefaultDb/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Test/>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/SqlServerTests/FlowMode/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/SqlServerTests/FlowMode/properties.xml
@@ -8,6 +8,7 @@
 <Search/>
 <Suite/>
 <SymbolicLinks>
+<AccessObjectsInNonDefaultDb>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.AccessObjectsInNonDefaultDb</AccessObjectsInNonDefaultDb>
 <BulkInsert>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsert</BulkInsert>
 <BulkInsertWithReturning>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsertWithReturning</BulkInsertWithReturning>
 <BulkInsertWithSchemaName>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.BulkInsertWithSchemaName</BulkInsertWithSchemaName>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/SqlServerTests/StandaloneFixtures/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/SqlServerTests/StandaloneFixtures/properties.xml
@@ -8,6 +8,7 @@
 <Search/>
 <Suite/>
 <SymbolicLinks>
+<AccessObjectsInNonDefaultDb>.DbFit.AcceptanceTests.DotNetTests.SqlServerTests.FlowMode.AccessObjectsInNonDefaultDb</AccessObjectsInNonDefaultDb>
 <CoreTests>.DbFit.AcceptanceTests.CoreTests</CoreTests>
 </SymbolicLinks>
 <Versions/>

--- a/dbfit-java/sqlserver/src/integration-test/resources/acceptancescripts-SqlServer.sql
+++ b/dbfit-java/sqlserver/src/integration-test/resources/acceptancescripts-SqlServer.sql
@@ -4,10 +4,19 @@ GO
 CREATE DATABASE [FitNesseTestDB]
 GO
 
+CREATE DATABASE [FitNesseTestDB2]
+GO
+
 /* Case sensitive collation - for additional required precision for testing */
 ALTER DATABASE [FitNesseTestDB] COLLATE Latin1_General_CS_AS
 /* Case insensitive collation
 ALTER DATABASE [FitNesseTestDB] COLLATE Latin1_General_CI_AS */
+GO
+
+/* Case sensitive collation - for additional required precision for testing */
+ALTER DATABASE [FitNesseTestDB2] COLLATE Latin1_General_CS_AS
+/* Case insensitive collation
+ALTER DATABASE [FitNesseTestDB2] COLLATE Latin1_General_CI_AS */
 GO
 
 CREATE LOGIN [FitNesseUser] WITH PASSWORD='FitNesseUser'
@@ -19,14 +28,28 @@ GO
 CREATE USER [FitNesseUser] FOR LOGIN [FitNesseUser] WITH DEFAULT_SCHEMA=[dbo]
 GO
 
+/* EXEC sp_addrolemember 'db_owner', 'FitNesseUser' */ /* SQL Server 2008 R2 or earlier */
+ALTER ROLE [db_owner] ADD MEMBER [FitNesseUser] /* SQL Server 2012 or later */
+GO
+
+ALTER DATABASE [FitNesseTestDB] SET READ_WRITE
+GO
+
+USE [FitNesseTestDB2]
+GO
+
+CREATE USER [FitNesseUser] FOR LOGIN [FitNesseUser] WITH DEFAULT_SCHEMA=[dbo]
+GO
+
+/* EXEC sp_addrolemember 'db_owner', 'FitNesseUser' */ /* SQL Server 2008 R2 or earlier */
 ALTER ROLE [db_owner] ADD MEMBER [FitNesseUser]
 GO
 
-ALTER DATABASE [FitNesseTestDB] SET  READ_WRITE
+ALTER DATABASE [FitNesseTestDB2] SET READ_WRITE
 GO
 
-
-
+USE [FitNesseTestDB]
+GO
 
 SET ANSI_NULLS ON
 GO
@@ -263,4 +286,31 @@ create procedure [dbo].[MakeUser] AS
 begin
 	insert into users (Name, UserName) values ('user1', 'fromproc');
 end
+GO
+
+USE FitNesseTestDB2
+GO
+
+CREATE TABLE [dbo].[Users2] (
+    Name     VARCHAR(50) NULL,
+    UserName VARCHAR(50) NULL,
+    UserId   INT IDENTITY(1,1) NOT NULL
+)
+GO
+
+CREATE PROCEDURE dbo.MakeUser2
+AS
+BEGIN
+    INSERT
+      INTO Users2
+           (
+           Name
+         , UserName
+           )
+    VALUES (
+           'user1'
+         , 'fromproc'
+           )
+    ;
+END
 GO

--- a/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
+++ b/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
@@ -69,7 +69,7 @@ public class SqlServerEnvironment extends AbstractDbEnvironment {
             throws SQLException {
         String qry = " select c.[name], TYPE_NAME(c.system_type_id) as [Type], c.max_length, "
                 + " 0 As is_output, 0 As is_cursor_ref "
-                + " from sys.columns c "
+                + " from " + objectDatabasePrefix(tableOrViewName) + "sys.columns c "
                 + " where c.object_id = OBJECT_ID(?) "
                 + " order by column_id";
         return readIntoParams(tableOrViewName, qry);
@@ -132,6 +132,15 @@ public class SqlServerEnvironment extends AbstractDbEnvironment {
     // private static string[] BinaryTypes=new string[] {"BINARY","VARBINARY", "TIMESTAMP"};
     // private static string[] GuidTypes = new string[] { "UNIQUEIDENTIFIER" };
     // private static string[] VariantTypes = new string[] { "SQL_VARIANT" };
+
+    private String objectDatabasePrefix(String dbObjectName) {
+        String objectDatabasePrefix = "";
+        String[] objnameParts = dbObjectName.split("\\.");
+        if (objnameParts.length == 3) {
+        	objectDatabasePrefix = objnameParts[0] + ".";
+        }
+        return objectDatabasePrefix;
+    }
 
     private static Direction getParameterDirection(int isOutput, String name) {
         if (name.isEmpty()) {
@@ -216,12 +225,12 @@ public class SqlServerEnvironment extends AbstractDbEnvironment {
                     + "       p.[name], TYPE_NAME(p.system_type_id) as [Type], "
                     + "       p.max_length, p.is_output, p.is_cursor_ref, "
                     + "       p.parameter_id, 0 as set_id, p.object_id "
-                    + "   from sys.parameters p "
+                    + "   from " + objectDatabasePrefix(procName) + "sys.parameters p "
                     + "   union all select "
                     + "        '' as [name], 'int' as [Type], "
                     + "        4 as max_length, 1 as is_output, 0 as is_cursor_ref, "
                     + "        null as parameter_id, 1 as set_id, object_id "
-                    + "   from sys.objects where type in (N'P', N'PC') "
+                    + "   from " + objectDatabasePrefix(procName) + "sys.objects where type in (N'P', N'PC') "
                     + ") as u where object_id = OBJECT_ID(?) order by set_id, parameter_id");
     }
 


### PR DESCRIPTION
Add support for access to objects that are not in the current database for the connection/session using the full 3 part name.

Users currently have to rely upon either the default database for the connection (specified for each DB user, or overridden for the connection using either the `database=` or `databaseName=` connection parameter), OR, set the default database using a `USE <db name>` SQL statement.