### PR TITLE
Publish dbfit jars to central

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,6 +228,31 @@ Please be aware that if you change any code whilst the `/.gradlew start` command
 
         dbfit$ ./gradlew starthere -PkeepTests
 
+#### Publishing to the Sonatype Central Repository (a.k.a. Maven Central)
+
+##### Uploading Development Version Snapshots
+
+* Create a new Sonatype user profile (`https://issues.sonatype.org/secure/Signup!default.jspa`).
+* Create a new support issue and register to upload DbFit (`com.github.dbfit`) artefacts.
+* Modify the DbFit version number string in the parent Gradle build script (in the DbFit development root directory). Ensure the version number string has the `-SNAPSHOT` suffix.
+* Upload the development version snapshot artefact to the Sonatype snapshots repository with:
+
+        dbfit$ ./gradlew uploadArchives
+
+##### Uploading Release Versions
+
+* Modify the DbFit version number string in the parent Gradle build script (in the DbFit development root directory). Ensure the version number string DOES NOT have the `-SNAPSHOT` suffix.
+* Create a public/private key pair for signing, cryptographically, of the build artefacts (i.e. DbFit JAR files). Follow the Sonatype guide (http://central.sonatype.org/pages/working-with-pgp-signatures.html).
+* Update `gradle.properties` in the DbFit development root directory with your public key, public key pass phrase and path to your secret keyring file.
+* Update `gradle.properties` in the DbFit development root directory with your Sonatype user name (`ossrhUsername`) and password (`ossrhPassword`).
+* Upload the release version artefact to the Sonatype staging repository:
+
+        dbfit$ ./gradlew uploadArchives
+
+##### Promoting Staged Release Versions
+
+* Log into the Sonatype dashboard, search for the DbFit project, and manually promote the staged artefacts.
+
 #### Using custom libraries
 
 If you need to use libraries which are not available on the public artifact repositories (e.g. proprietary JDBC drivers) - you may place them in `custom_libs` directory. This folder is configured as [flat directory repository](http://www.gradle.org/docs/current/userguide/dependency_management.html#sec:flat_dir_resolver) in Gradle - the typical naming format of JARs inside is `<main_name>-<version>.jar`.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
-ext.dbfitVersion = '3.1.0'
+ext.dbfitVersion = '3.2.0-SNAPSHOT'
+ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 task cleanFitnesseroot(type:Exec) {
     def gitArgs = ['clean', '-d', '-x', '-f', 'FitNesseRoot/']

--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -4,16 +4,15 @@ ext {
 }
 
 allprojects {
+    apply plugin: 'java'
+    apply plugin: 'checkstyle'
     apply plugin: 'idea'
     apply plugin: 'eclipse'
-
     apply plugin: 'maven'
-    group = 'com.neuri.dbfit'
-    version = rootProject.dbfitVersion
-    
-    apply plugin: 'java'
+    apply plugin: 'signing'
 
-    apply plugin: 'checkstyle'
+    group = 'com.github.dbfit'
+    version = rootProject.dbfitVersion
 
     checkstyle {
         configFile = new File(parent.projectDir, "config/checkstyle/checkstyle.xml")
@@ -22,6 +21,17 @@ allprojects {
     tasks.withType(JavaCompile) {
         options.compilerArgs << "-Xlint:unchecked"
         options.compilerArgs << "-Xlint:deprecation"
+    }
+
+    // Suppress stricter Java 8 Javadoc checks.
+    if (JavaVersion.current().isJava8Compatible()) {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+
+    dependencies {
+        compile "org.fitnesse:fitnesse:${fitNesseVersion}:standalone@jar"
     }
 }
 
@@ -62,7 +72,7 @@ subprojects {
         testCompile "org.hamcrest:java-hamcrest:2.0.0.0"
         testCompile "commons-io:commons-io:2.4"
         testRuntime 'com.dbdeploy:dbdeploy-ant:3.0M3'
-        integrationTestCompile "dummy:fitnesse-standalone:${fitNesseVersion}@jar"
+        integrationTestCompile "org.fitnesse:fitnesse:${fitNesseVersion}:standalone@jar"
     }
 
     task integrationTestJar(type: Jar) {
@@ -97,15 +107,18 @@ subprojects {
 task assembleAll(dependsOn: subprojects.assemble) { }
 task libs(dependsOn: subprojects.libs) { }
 
+def publicCoreCompileDeps = [
+    'org.reflections:reflections:0.9.9',
+    'commons-codec:commons-codec:1.10',
+    'org.apache.commons:commons-lang3:3.4',
+    'com.github.dbfit:fitlibrary:20091020'
+]
+
 project('core') {
     description = 'DBFit core api and fixtures'
 
     dependencies {
-        compile "dummy:fitnesse-standalone:${fitNesseVersion}@jar"
-        compile "dummy:fitlibrary:20091020@jar"
-        compile "org.reflections:reflections:0.9.9"
-        compile "commons-codec:commons-codec:1.10"
-        compile "org.apache.commons:commons-lang3:3.4"
+        compile publicCoreCompileDeps
         testCompile "org.mockito:mockito-core:${mockitoVersion}"
     }
 }
@@ -133,22 +146,30 @@ project('derby') {
     }
 }
 
+def publicHsqldbRuntimeDeps = [
+    'org.hsqldb:hsqldb:2.3.2@jar'
+]
+
 project('hsqldb') {
     description = 'DBFit HSQLDB engine'
 
     dependencies {
         compile project(':dbfit-java:core')
-        runtime 'org.hsqldb:hsqldb:2.3.2@jar'
+        runtime publicHsqldbRuntimeDeps
     }
 }
+
+def publicOracleCompileDeps = [
+    'commons-io:commons-io:2.4'
+]
 
 project('oracle') {
     description = 'DBFit Oracle engine'
 
     dependencies {
         compile project(':dbfit-java:core')
-        compile "commons-io:commons-io:2.4"
         compile 'dummy:ojdbc6:11.2.0.3.0@jar'
+        compile publicOracleCompileDeps
         testCompile "org.mockito:mockito-core:${mockitoVersion}"
     }
 
@@ -167,12 +188,16 @@ project('oracle') {
     }
 }
 
+def publicMysqlCompileDeps = [
+    'mysql:mysql-connector-java:5.1.6'
+]
+
 project('mysql') {
     description = 'DBFit MySQL engine'
 
     dependencies {
         compile project(':dbfit-java:core')
-        compile group: 'mysql', name: 'mysql-connector-java', version: '5.1.6'
+        compile publicMysqlCompileDeps
     }
 
     integrationTest.doFirst {
@@ -180,12 +205,16 @@ project('mysql') {
     }
 }
 
+def publicPostgresCompileDeps = [
+    'org.postgresql:postgresql:9.3-1101-jdbc41'
+]
+
 project('postgres') {
     description = 'DBFit PostGreSQL engine'
 
     dependencies {
         compile project(':dbfit-java:core')
-        compile group: 'org.postgresql', name: 'postgresql', version: '9.3-1101-jdbc41'
+        compile publicPostgresCompileDeps
     }
 
     integrationTest.doFirst {
@@ -198,7 +227,7 @@ project('sqlserver') {
 
     dependencies {
         compile project(':dbfit-java:core')
-        testRuntime 'com.microsoft:sqljdbc:4.1.5605@jar'
+        runtime 'com.microsoft:sqljdbc:4.1.5605@jar'
         integrationTestRuntime 'com.microsoft:sqljdbc:4.1.5605@jar'
     }
 }
@@ -222,3 +251,95 @@ project('netezza') {
     }
 }
 
+// Aggregated dependencies to include in the POM file when publishing.
+dependencies {
+    compile publicCoreCompileDeps
+    runtime publicHsqldbRuntimeDeps
+    compile publicOracleCompileDeps
+    compile publicMysqlCompileDeps
+    compile publicPostgresCompileDeps
+}
+
+// Remove the default artifact as there are no Java sources for this project.
+configurations.archives.artifacts.clear()
+
+task allJavadoc(type: Javadoc) {
+    source subprojects.collect { it.sourceSets.main.allJava }
+    destinationDir = new File(buildDir, 'doc/javadoc')
+    classpath = files(subprojects.collect { it.sourceSets.main.compileClasspath })
+}
+
+task allJavadocJar(type: Jar) {
+    baseName = 'dbfit'
+    classifier = 'javadoc'
+    from allJavadoc
+}
+
+task allSourcesJar(type: Jar) {
+    baseName = 'dbfit'
+    classifier = 'sources'
+    subprojects.each { from it.sourceSets.main.allSource }
+}
+
+task allJar(type: Jar, dependsOn: subprojects.build) {
+    baseName = 'dbfit'
+    subprojects.each { from it.configurations.archives.allArtifacts.files.collect { zipTree(it) } }
+}
+
+artifacts {
+    archives allJar, allJavadocJar, allSourcesJar
+}
+
+signing {
+    required { rootProject.isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives") }
+    sign configurations.archives
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment {
+                MavenDeployment deployment -> signing.signPom(deployment)
+            }
+
+            if (!project.hasProperty('ossrhUsername')) {
+                project.ext.set('ossrhUsername', '')
+            }
+
+            if (!project.hasProperty('ossrhPassword')) {
+                project.ext.set('ossrhPassword', '')
+            }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            pom.project {
+                name 'DbFit'
+                packaging 'jar'
+                description 'Database test automation for FitNesse'
+
+                url 'http://dbfit.github.io/dbfit/index.html'
+                scm {
+                    connection 'scm:git@github.com/dbfit/dbfit.git'
+                    developerConnection 'scm:git@github.com/dbfit/dbfit.git'
+                    url 'https://github.com/dbfit/dbfit.git'
+                }
+
+                licenses {
+                    license {
+                        name 'GNU General Public License, version 2'
+                        url 'https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html'
+                    }
+                }
+
+                developers {
+                }
+            }
+        }
+     }
+}

--- a/gradle.properties.publishing-sample
+++ b/gradle.properties.publishing-sample
@@ -1,0 +1,6 @@
+signing.keyId=<publicKey>
+signing.password=<keyPassPhrase>
+signing.secretKeyRingFile=path/to/secret/keyring/file
+
+ossrhUsername=<Sonatype username>
+ossrhPassword=<Sonatype password>

--- a/templates/startFitnesse.bat.tmpl
+++ b/templates/startFitnesse.bat.tmpl
@@ -1,3 +1,3 @@
 cd /d %~dp0
-java -cp "lib\dbfit-docs-@dbfitVersion@.jar;lib\fitnesse-standalone-@fitNesseVersion@.jar" fitnesseMain.FitNesseMain %*
+java -cp "lib\dbfit-docs-@dbfitVersion@.jar;lib\fitnesse-@fitNesseVersion@-standalone.jar" fitnesseMain.FitNesseMain %*
 pause

--- a/templates/startFitnesse.sh.tmpl
+++ b/templates/startFitnesse.sh.tmpl
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd `dirname $0`
-java -cp 'lib/dbfit-docs-@dbfitVersion@.jar:lib/fitnesse-standalone-@fitNesseVersion@.jar' fitnesseMain.FitNesseMain $@
+java -cp 'lib/dbfit-docs-@dbfitVersion@.jar:lib/fitnesse-@fitNesseVersion@-standalone.jar' fitnesseMain.FitNesseMain $@


### PR DESCRIPTION
To resolve #173.

`uploadArchives` task creates additional JAR files instead of using the existing JAR output libraries: -
* dbfit-x.y.z[-SNAPSHOT].jar
* dbfit-x.y.z-sources[-SNAPSHOT].jar
* dbfit-x.y.z-javadoc[-SNAPSHOT].jar

then signs the archives and uploads to the appropriate (SNAPSHOT or release staging) Sonatype Maven repository.

All dependencies are published in the associated POM file. The exception is FitLibrary as the version currently used by DbFit isn't available from public repositories (a point for discussion).
