### PR TITLE
test vm: workaround for swap cookbook for chef 12

### DIFF
--- a/test_vm/Cheffile
+++ b/test_vm/Cheffile
@@ -6,3 +6,4 @@ site 'http://community.opscode.com/api/v1'
 cookbook 'dbfit_test', :path => "vendor/cookbooks/dbfit_test"
 
 cookbook 'database', :git => "https://github.com/dbfit/database"
+cookbook 'swap', :git => "https://github.com/dbfit/swap"


### PR DESCRIPTION
Switch to more recent (not yet pulled automatically by chef) `swap` cookbook in order to workaround compatibility issues with chef 12

This intends to resolve #381 