### PR TITLE
Refactor checkConnectionValid

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
@@ -137,8 +137,7 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
     }
 
     public void rollback() throws SQLException {
-        checkConnectionValid(currentConnection);
-        currentConnection.rollback();
+        getConnection().rollback();
     }
 
     /*****/
@@ -222,11 +221,15 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
     /** Check the validity of the supplied connection. */
     public static void checkConnectionValid(final Connection conn)
             throws SQLException {
-        if (conn == null || conn.isClosed()) {
+        if (! isConnected(conn)) {
             throw new IllegalArgumentException(
                     "No open connection to a database is available. "
                             + "Make sure your database is running and that you have connected before performing any queries.");
         }
+    }
+
+    private static boolean isConnected(final Connection conn) throws SQLException {
+        return (conn != null && !conn.isClosed());
     }
 
 }

--- a/dbfit-java/derby/src/main/java/dbfit/environment/DerbyEnvironment.java
+++ b/dbfit-java/derby/src/main/java/dbfit/environment/DerbyEnvironment.java
@@ -61,8 +61,7 @@ public class DerbyEnvironment extends AbstractDbEnvironment {
 
     private Map<String, DbParameterAccessor> readIntoParams(
             String tableOrViewName, String query) throws SQLException {
-        checkConnectionValid(currentConnection);
-        try (PreparedStatement dc = currentConnection.prepareStatement(query)) {
+        try (PreparedStatement dc = getConnection().prepareStatement(query)) {
             dc.setString(1, tableOrViewName);
 
             ResultSet rs = dc.executeQuery();

--- a/dbfit-java/hsqldb/src/main/java/dbfit/environment/HSQLDBEnvironment.java
+++ b/dbfit-java/hsqldb/src/main/java/dbfit/environment/HSQLDBEnvironment.java
@@ -72,8 +72,7 @@ public class HSQLDBEnvironment extends AbstractDbEnvironment {
 
     private Map<String, DbParameterAccessor> readIntoParams(
             String tableOrViewName, String query) throws SQLException {
-        checkConnectionValid(currentConnection);
-        try (PreparedStatement dc = currentConnection.prepareStatement(query)) {
+        try (PreparedStatement dc = getConnection().prepareStatement(query)) {
 
             String tvname;
             if (tableOrViewName.trim().startsWith("\"") && tableOrViewName.trim().endsWith("\"")) {


### PR DESCRIPTION
Reduce direct calls to `checkConnectionValid` to simplify dependencies (as validity check is already performed by `getConnection`)