### PR TITLE
Auto commit support fixes

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/CoreTests/CommonSuite/CommitAndRollback/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/CoreTests/CommonSuite/CommitAndRollback/content.txt
@@ -1,3 +1,5 @@
+!|Rollback|
+
 !|set option|autocommit|false|
 
 !|Execute Ddl|create table TESTTBL(ID int, VAL int)|
@@ -29,3 +31,5 @@
 
 !|Execute Ddl|drop table TESTTBL|
 !|Commit|
+
+!|set option|autocommit|false|

--- a/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
@@ -133,11 +133,15 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
     }
 
     public void commit() throws SQLException {
-        currentConnection.commit();
+        if (!getConnection().getAutoCommit()) {
+            currentConnection.commit();
+        }
     }
 
     public void rollback() throws SQLException {
-        getConnection().rollback();
+        if (!getConnection().getAutoCommit()) {
+            currentConnection.rollback();
+        }
     }
 
     @Override


### PR DESCRIPTION
A few fixes on top of #385

* Don't rollback or commit when autocommit is true
    
    Some jdbc implementations raise exception on attempt to call `commit` or `rollback` in `autocommit=true` mode (e.g. mysql and postgresql).

* Rollback and reset to false around autocommit=true
  
    In CommitAndRollback acceptance test: rollback before setting `autocommit=true` and reset to `autocommit=false` at the end of test page. This is in order to avoid side effects due to:
     * `setAutoCommit` performs implicit commit
     * `autocommit`option value might span to other tests in standalone mode
