### PR TITLE
migrate travis to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
    - "ARTIFACTS_S3_BUCKET=dbfit"
    - secure: "NLAj1hPcTlzBO6hEbZ3X6AOfXUVeFl0oSytrd02m+UaXzbNA9PZ6ZjYBwCGA\nvpNdVd5YVNMaUWBX5IN336mscvJswg+9lyt3y8cgBzOUWNE/UXDRXYoL8xwx\nxXnMnBatW2+0M4QtuXyLZpWyPxKa+1AYuCVJXHaANrkjufuXm04="
    - secure: "li8rtIJ0NxvXPn2o1TltT+CaiMyfN0neFoBBA7CXCRWOt0Gjs6ytzP89Hclu\nbdPuZsCXXKckW3UIIzqR6YDU0NhLZxkZuOz0u3+dD1856jqa2umXJi3MnQ6j\nlulUkNwfmE+ul0Hly0Hia4nNivHQ3f4I7BNSQlNM0GVYy+ZL4Oo="
+sudo: false
 language: java
 before_install:
   - "./gradlew -version"


### PR DESCRIPTION
Recent Travis builds have raised a warning:

"This job ran on our legacy infrastructure. Please read [our docs on how to upgrade](http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade)"

This PR is attempting to migrate to container-based infrastructure as advised.

