### PR TITLE
Add developers list to uploadArchives pom definition

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -338,6 +338,18 @@ uploadArchives {
                 }
 
                 developers {
+                    developer {
+                        id "benilovj"
+                        name "Jake Benilov"
+                    }
+                    developer {
+                        id "javornikolov"
+                        name "Yavor Nikolov"
+                    }
+                    developer {
+                        id "mmatten"
+                        name "Mark Matten"
+                    }
                 }
             }
         }


### PR DESCRIPTION
Seems Maven Central requires developers list for final releases (otherwise "Close" operation will fail).