### PR TITLE
Support non-transactional databases

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
@@ -126,7 +126,7 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
 
     public void closeConnection() throws SQLException {
         if (currentConnection != null) {
-            currentConnection.rollback();
+            rollback();
             currentConnection.close();
             currentConnection = null;
         }
@@ -148,7 +148,9 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
     public void setAutoCommit() throws SQLException {
         String autoCommitMode = Options.get(OPTION_AUTO_COMMIT);
         if (!"auto".equals(autoCommitMode) && isConnected(currentConnection)) {
-            currentConnection.setAutoCommit(Options.is(OPTION_AUTO_COMMIT));
+            if (currentConnection.getMetaData().supportsTransactions()) {
+                currentConnection.setAutoCommit(Options.is(OPTION_AUTO_COMMIT));
+            }
         }
     }
 


### PR DESCRIPTION
Do not attempt to change auto-commit behaviour for non-transactional databases.

This change is required to support Informix databases running in Informix rather than ANSI mode.