### PR TITLE
MySql: support for unreferenced BIT columns

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/MySqlTests/FlowMode/DataTypes/BitTests/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/MySqlTests/FlowMode/DataTypes/BitTests/content.txt
@@ -1,0 +1,25 @@
+!3 Unreferenced BIT data type (allow operations on tables with BIT fields)
+
+BIT type is in general not supported but it should work fine to operate on other columns when a BIT field is not referenced
+
+|Execute|Create table datatypetest (b1 BIT, n2 INT)|
+
+|Insert|datatypetest|
+|n2|
+|13|
+
+|Query|Select n2 from datatypetest|
+|n2|
+|13|
+
+|Update|datatypetest|
+|n2|n2=|
+|13|7  |
+
+|Query|Select n2 from datatypetest|
+|n2|
+|7 |
+
+|Clean|
+|table|clean?|
+|datatypetest|true|

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/MySqlTests/FlowMode/DataTypes/BitTests/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/MySqlTests/FlowMode/DataTypes/BitTests/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Test/>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/dbfit-java/mysql/src/main/java/dbfit/environment/MySqlEnvironment.java
+++ b/dbfit-java/mysql/src/main/java/dbfit/environment/MySqlEnvironment.java
@@ -109,6 +109,7 @@ public class MySqlEnvironment extends AbstractDbEnvironment {
             "TIMESTAMP", "DATETIME" });
     private static List<String> timeTypes = Arrays.asList("TIME");
     private static List<String> refCursorTypes = Arrays.asList(new String[] {});
+    private static List<String> bitTypes = Arrays.asList("BIT");
 
     private static String normaliseTypeName(String dataType) {
         dataType = dataType.toUpperCase().trim();
@@ -141,6 +142,8 @@ public class MySqlEnvironment extends AbstractDbEnvironment {
             return java.sql.Types.TIME;
         if (refCursorTypes.contains(dataType))
             return java.sql.Types.REF;
+        if (bitTypes.contains(dataType))
+            return java.sql.Types.BIT;
         throw new UnsupportedOperationException("Type " + dataType
                 + " is not supported");
     }
@@ -169,6 +172,8 @@ public class MySqlEnvironment extends AbstractDbEnvironment {
             return java.sql.Timestamp.class;
         if (timeTypes.contains(dataType))
             return java.sql.Time.class;
+        if (bitTypes.contains(dataType))
+            return Boolean.class;
         throw new UnsupportedOperationException("Type " + dataType
                 + " is not supported");
     }


### PR DESCRIPTION
This is to be able to support e.g. updating table which contains BIT column via dbfit Update fixture when the bit column itself is not referenced.

Also it's possibly covering (but not yet tested) referring **single** `BIT` columns `BIT (1)`. For longer BIT data types `BIT(n > 1)` referring such columns is not supported.

As per the [MySql driver documentation](https://dev.mysql.com/doc/connector-j/en/connector-j-reference-type-conversions.html): the Java type is different for BIT(1) and BIT(n > 1).

TODO:
 - [x] Add acceptance tests
 - [x] Test if the original problem is being solved

---

The problem has been originally reported on the mailing list. Update like following.

```
|Update |mytable |
|field1= |field2 |
|value1 |value2 |
```

results in exception:

```
java.lang.UnsupportedOperationException: Type BIT is not supported
 at dbfit.environment.MySqlEnvironment.getSqlType(MySqlEnvironment.java:143)
 at dbfit.environment.MySqlEnvironment.readColumnsFromDb(MySqlEnvironment.java:79)
 at dbfit.environment.MySqlEnvironment.getAllColumns(MySqlEnvironment.java:61)
 at dbfit.fixture.Update.initParameters(Update.java:101)
 at dbfit.fixture.Update.doRows(Update.java:86)
 at fit.Fixture.doTable(Fixture.java:156)
 at fitlibrary.traverse.AlienTraverseHandler.doTable(AlienTraverseHandler.java:21)
 at fitlibrary.traverse.workflow.DoTraverseInterpreter.interpretWholeTable(DoTraverseInterpreter.java:104)
 at fitlibrary.traverse.workflow.DoTraverseInterpreter.interpretWholeTable(DoTraverseInterpreter.java:89)
 at fitlibrary.DoFixture.interpretWholeTable(DoFixture.java:73)
 at fitlibrary.suite.InFlowPageRunner.run(InFlowPageRunner.java:27)
 at fitlibrary.DoFixture.interpretTables(DoFixture.java:42)
 at dbfit.DatabaseTest.interpretTables(DatabaseTest.java:26)
 at fit.Fixture.doTables(Fixture.java:81)
 at fit.FitServer.process(FitServer.java:81)
 at fit.FitServer.run(FitServer.java:56)
 at fit.FitServer.main(FitServer.java:41)
```

The columns in the UPDATE are varchar but there is a bit field in the table.