### PR TITLE
Allow DB-specific type-casting before PreparedStatement object binding

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
@@ -257,5 +257,9 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
     public void setTypeSpecifier(Class<?> targetClass, TypeSpecifier specifier) {
         typeSpecifiers.put(targetClass, specifier);
     }
+    
+    public Map<Class<?>, TypeSpecifier> getTypeSpecifierMap() {
+        return typeSpecifiers;
+    }
 }
 

--- a/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
@@ -7,6 +7,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.sql.*;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.Properties;
@@ -246,5 +248,14 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
         return (conn != null && !conn.isClosed());
     }
 
+    private Map<Class<?>, TypeSpecifier> typeSpecifiers = new HashMap<Class<?>, TypeSpecifier>();
+
+    public TypeSpecifier getTypeSpecifier(Class<?> targetClass) {
+    	return typeSpecifiers.get(targetClass);
+    }
+
+    public void setTypeSpecifier(Class<?> targetClass, TypeSpecifier specifier) {
+        typeSpecifiers.put(targetClass, specifier);
+    }
 }
 

--- a/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
@@ -2,6 +2,7 @@ package dbfit.api;
 
 import dbfit.util.DbParameterAccessor;
 import dbfit.util.NameNormaliser;
+import dbfit.util.TypeSpecifier;
 import dbfit.util.DdlStatementExecution;
 
 import java.io.FileNotFoundException;
@@ -179,5 +180,17 @@ public interface DBEnvironment {
             FileNotFoundException;
 
     DbStoredProcedureCall newStoredProcedureCall(String name, DbParameterAccessor[] accessors);
+
+    /**
+     * Get the TypeSpecifier factory object, for the given class, used to create a DB adapter-specific
+     * variant of an object of the given class.    
+     */
+    public TypeSpecifier getTypeSpecifier(Class<?> targetClass);
+
+    /**
+     * Set the TypeSpecifier factory object, for the given class, used to create a DB adapter-specific
+     * variant of an object of the given class.    
+     */
+    public void setTypeSpecifier(Class<?> targetClass, TypeSpecifier specifier);
 }
 

--- a/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
@@ -183,18 +183,18 @@ public interface DBEnvironment {
 
     /**
      * Get the TypeSpecifier factory object, for the given class, used to create a DB adapter-specific
-     * variant of an object of the given class.    
+     * variant of an object of the given class.
      */
     public TypeSpecifier getTypeSpecifier(Class<?> targetClass);
 
     /**
      * Set the TypeSpecifier factory object, for the given class, used to create a DB adapter-specific
-     * variant of an object of the given class.    
+     * variant of an object of the given class.
      */
     public void setTypeSpecifier(Class<?> targetClass, TypeSpecifier specifier);
-    
+
     /**
-     * Return the collection of TypeSpecifier objects, used to create DB adaptor specific variants of object
+     * Return the collection of TypeSpecifier objects used to create DB adaptor specific variants of objects
      * of the given classes. 
      */
     public Map<Class<?>, TypeSpecifier> getTypeSpecifierMap();

--- a/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
@@ -192,5 +192,11 @@ public interface DBEnvironment {
      * variant of an object of the given class.    
      */
     public void setTypeSpecifier(Class<?> targetClass, TypeSpecifier specifier);
+    
+    /**
+     * Return the collection of TypeSpecifier objects, used to create DB adaptor specific variants of object
+     * of the given classes. 
+     */
+    public Map<Class<?>, TypeSpecifier> getTypeSpecifierMap();
 }
 

--- a/dbfit-java/core/src/main/java/dbfit/api/DbStatement.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStatement.java
@@ -20,6 +20,6 @@ public class DbStatement {
     }
 
     public StatementExecution buildPreparedStatement() throws SQLException {
-        return new StatementExecution(environment.createStatementWithBoundFixtureSymbols(testHost, statementText), false, environment);
+        return new StatementExecution(environment.createStatementWithBoundFixtureSymbols(testHost, statementText), false, environment.getTypeSpecifierMap());
     }
 }

--- a/dbfit-java/core/src/main/java/dbfit/api/DbStatement.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStatement.java
@@ -20,6 +20,6 @@ public class DbStatement {
     }
 
     public StatementExecution buildPreparedStatement() throws SQLException {
-        return new StatementExecution(environment.createStatementWithBoundFixtureSymbols(testHost, statementText), false);
+        return new StatementExecution(environment.createStatementWithBoundFixtureSymbols(testHost, statementText), false, environment);
     }
 }

--- a/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
@@ -51,7 +51,7 @@ public class DbStoredProcedureCall {
     }
 
     public StatementExecution toStatementExecution() throws SQLException {
-        StatementExecution cs = new StatementExecution(this.environment.getConnection().prepareCall(toSqlString()));
+        StatementExecution cs = new StatementExecution(this.environment.getConnection().prepareCall(toSqlString()), environment);
         bindParametersTo(cs);
         return cs;
     }

--- a/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
@@ -51,7 +51,7 @@ public class DbStoredProcedureCall {
     }
 
     public StatementExecution toStatementExecution() throws SQLException {
-        StatementExecution cs = new StatementExecution(this.environment.getConnection().prepareCall(toSqlString()), environment);
+        StatementExecution cs = new StatementExecution(this.environment.getConnection().prepareCall(toSqlString()), environment.getTypeSpecifierMap());
         bindParametersTo(cs);
         return cs;
     }

--- a/dbfit-java/core/src/main/java/dbfit/api/DbTable.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbTable.java
@@ -30,8 +30,8 @@ public class DbTable implements DbObject {
 
     public StatementExecution buildPreparedStatement(
             DbParameterAccessor[] accessors) throws SQLException {
-        StatementExecution statement = new StatementExecution(dbEnvironment
-                .buildInsertPreparedStatement(tableOrViewName, accessors), dbEnvironment);
+        StatementExecution statement = new StatementExecution(dbEnvironment.buildInsertPreparedStatement(tableOrViewName, accessors),
+                                                              dbEnvironment.getTypeSpecifierMap());
 
         for (int i = 0; i < accessors.length; i++) {
             accessors[i].bindTo(statement, i + 1);

--- a/dbfit-java/core/src/main/java/dbfit/api/DbTable.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbTable.java
@@ -31,7 +31,7 @@ public class DbTable implements DbObject {
     public StatementExecution buildPreparedStatement(
             DbParameterAccessor[] accessors) throws SQLException {
         StatementExecution statement = new StatementExecution(dbEnvironment
-                .buildInsertPreparedStatement(tableOrViewName, accessors));
+                .buildInsertPreparedStatement(tableOrViewName, accessors), dbEnvironment);
 
         for (int i = 0; i < accessors.length; i++) {
             accessors[i].bindTo(statement, i + 1);

--- a/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
@@ -41,9 +41,9 @@ public class StatementExecution implements AutoCloseable {
             TypeSpecifier ts = typeMap.get(value.getClass());
             Object newValue;
             if (ts != null) {
-            	newValue = ts.specify(value);
+                newValue = ts.specify(value);
             } else {
-            	newValue = value;
+                newValue = value;
             }
             // Don't use the variant that takes sqlType.
             // Derby (at least) assumes no decimal places for Types.DECIMAL and truncates the source data.

--- a/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
@@ -1,20 +1,22 @@
 package dbfit.fixture;
 
 import java.sql.*;
-import dbfit.api.DBEnvironment;
+import java.util.HashMap;
+import java.util.Map;
+
 import dbfit.util.TypeSpecifier;
 
 public class StatementExecution implements AutoCloseable {
     private PreparedStatement statement;
-    private DBEnvironment environment;
+    private Map<Class<?>, TypeSpecifier> typeMap;
 
-    public StatementExecution(PreparedStatement statement, DBEnvironment env) {
-        this(statement, true, env);
+    public StatementExecution(PreparedStatement statement, Map<Class<?>, TypeSpecifier> ts) {
+        this(statement, true, ts);
     }
 
-    public StatementExecution(PreparedStatement statement, boolean clearParameters, DBEnvironment env) {
+    public StatementExecution(PreparedStatement statement, boolean clearParameters, Map<Class<?>, TypeSpecifier> ts) {
         this.statement = statement;
-        this.environment = env;
+        this.typeMap = ts;
         if (clearParameters) {
             try {
                 statement.clearParameters();
@@ -36,7 +38,7 @@ public class StatementExecution implements AutoCloseable {
         if (value == null) {
             statement.setNull(index, sqlType, userDefinedTypeName);
         } else {
-            TypeSpecifier ts = environment.getTypeSpecifier(value.getClass());
+            TypeSpecifier ts = typeMap.get(value.getClass());
             Object newValue;
             if (ts != null) {
             	newValue = ts.specify(value);

--- a/dbfit-java/core/src/main/java/dbfit/fixture/Update.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/Update.java
@@ -61,7 +61,7 @@ public class Update extends fit.Fixture {
         }
 
         StatementExecution cs =
-            new StatementExecution(environment.getConnection().prepareStatement(s.toString()), environment);
+            new StatementExecution(environment.getConnection().prepareStatement(s.toString()), environment.getTypeSpecifierMap());
 
         for (int i = 0; i < updateAccessors.length; i++) {
             updateAccessors[i].bindTo(cs, i + 1);

--- a/dbfit-java/core/src/main/java/dbfit/fixture/Update.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/Update.java
@@ -61,7 +61,7 @@ public class Update extends fit.Fixture {
         }
 
         StatementExecution cs =
-            new StatementExecution(environment.getConnection().prepareStatement(s.toString()));
+            new StatementExecution(environment.getConnection().prepareStatement(s.toString()), environment);
 
         for (int i = 0; i < updateAccessors.length; i++) {
             updateAccessors[i].bindTo(cs, i + 1);

--- a/dbfit-java/core/src/main/java/dbfit/util/TypeSpecifier.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/TypeSpecifier.java
@@ -1,0 +1,7 @@
+package dbfit.util;
+
+import java.sql.SQLException;
+
+public interface TypeSpecifier {
+    public Object specify(Object o) throws SQLException ;
+}

--- a/dbfit-java/core/src/test/java/dbfit/environment/DummyDriver.java
+++ b/dbfit-java/core/src/test/java/dbfit/environment/DummyDriver.java
@@ -1,0 +1,4 @@
+package dbfit.environment;
+
+public class DummyDriver {
+}

--- a/dbfit-java/core/src/test/java/dbfit/environment/DummyEnvironment.java
+++ b/dbfit-java/core/src/test/java/dbfit/environment/DummyEnvironment.java
@@ -1,0 +1,49 @@
+package dbfit.environment;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+
+import dbfit.annotations.DatabaseEnvironment;
+import dbfit.api.AbstractDbEnvironment;
+import dbfit.util.DbParameterAccessor;
+
+@DatabaseEnvironment(name="Dummy", driver="dbfit.environment.DummyDriver")
+public class DummyEnvironment extends AbstractDbEnvironment {
+
+    public DummyEnvironment(String driverClassName) {
+        super("dbfit.environment.DummyDriver");
+    }
+
+    @Override
+    public String getConnectionString(String dataSource) {
+        return "jdbc:dummy";
+    }
+
+    @Override
+    protected String getConnectionString(String dataSource, String database) {
+        return "jdbc:dummy";
+    }
+
+    @Override
+    public Map<String, DbParameterAccessor> getAllColumns(final String tableOrViewName) {
+        return new HashMap<String, DbParameterAccessor>();
+    }
+
+    @Override
+    public Map<String, DbParameterAccessor> getAllProcedureParameters(String procName) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Class<?> getJavaClass(String dataType) {
+        return String.class;
+    }
+
+    @Override
+    public Pattern getParameterPattern() {
+        return Pattern.compile("");
+    }
+}

--- a/dbfit-java/core/src/test/java/dbfit/environment/TypeSpecifierTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/environment/TypeSpecifierTest.java
@@ -4,6 +4,8 @@ import org.junit.*;
 import static org.junit.Assert.*;
 
 import java.sql.SQLException;
+import java.util.Map;
+
 import dbfit.api.DBEnvironment;
 
 import dbfit.util.TypeSpecifier;
@@ -17,18 +19,11 @@ public class TypeSpecifierTest {
     }
 
     @Test
-    public void setAndGetTypeSpecifierTest() {
-        DBEnvironment env = dbfit.api.DbEnvironmentFactory.newEnvironmentInstance("Dummy");
-        env.setTypeSpecifier(Integer.class, new DummyTypeSpecifier());
-        TypeSpecifier ts = env.getTypeSpecifier(Integer.class);
-        assertNotNull(ts);
-    }
-
-    @Test
     public void castTypeTest() {
         DBEnvironment env = dbfit.api.DbEnvironmentFactory.newEnvironmentInstance("Dummy");
         env.setTypeSpecifier(java.util.Date.class, new DummyTypeSpecifier());
-        TypeSpecifier ts = env.getTypeSpecifier(java.util.Date.class);
+        Map<Class<?>, TypeSpecifier> tsm = env.getTypeSpecifierMap();
+        TypeSpecifier ts = tsm.get(java.util.Date.class);
         String s = null;
         try {
             s = (String) ts.specify(new java.util.Date());

--- a/dbfit-java/core/src/test/java/dbfit/environment/TypeSpecifierTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/environment/TypeSpecifierTest.java
@@ -1,0 +1,40 @@
+package dbfit.environment;
+
+import org.junit.*;
+import static org.junit.Assert.*;
+
+import java.sql.SQLException;
+import dbfit.api.DBEnvironment;
+
+import dbfit.util.TypeSpecifier;
+
+public class TypeSpecifierTest {
+
+    private class DummyTypeSpecifier implements TypeSpecifier {
+        public Object specify(Object o) throws SQLException {
+            return new String("abcdef");
+        }
+    }
+
+    @Test
+    public void setAndGetTypeSpecifierTest() {
+        DBEnvironment env = dbfit.api.DbEnvironmentFactory.newEnvironmentInstance("Dummy");
+        env.setTypeSpecifier(Integer.class, new DummyTypeSpecifier());
+        TypeSpecifier ts = env.getTypeSpecifier(Integer.class);
+        assertNotNull(ts);
+    }
+
+    @Test
+    public void castTypeTest() {
+        DBEnvironment env = dbfit.api.DbEnvironmentFactory.newEnvironmentInstance("Dummy");
+        env.setTypeSpecifier(java.util.Date.class, new DummyTypeSpecifier());
+        TypeSpecifier ts = env.getTypeSpecifier(java.util.Date.class);
+        String s = null;
+        try {
+            s = (String) ts.specify(new java.util.Date());
+        } catch (SQLException e) {
+            fail();
+        }
+        assertEquals(s, "abcdef");
+    }
+}


### PR DESCRIPTION
Allow DB environment-specific type casting (of objects normalised by `TypeNormaliser` objects) before passing to `PreparedStatement`s `setObject` method.

For consideration and in support of enhancement of PR #436.

* Units tests still to be created - using a dummy `DBEnvironment` object.
* `StatementExecution` constructors - it probably makes sense to remove the passed `PreparedStatement` object as this could be created via the passed `DBEnvironment` object, BUT, then unit tests will require a DB connection (potentially making the `core` interdependent upon one or more `DBEnvironment` implementations).
