### PR TITLE
Generalise TypeNormaliser mechanism

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/util/BigDecimalNormaliser.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/BigDecimalNormaliser.java
@@ -2,10 +2,10 @@ package dbfit.util;
 
 import java.math.BigDecimal;
 
-public class BigDecimalNormaliser implements TypeNormaliser {
+public class BigDecimalNormaliser implements TypeTransformer {
 
     @Override
-    public Object normalise(final Object o) {
+    public Object transform(final Object o) {
         return (o == null) ? null : new NormalisedBigDecimal((BigDecimal) o);
     }
 }

--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
@@ -20,8 +20,8 @@ public class DbParameterAccessor {
 
     public static Object normaliseValue(Object currVal) throws SQLException {        
         if (currVal==null) return null;
-        TypeNormaliser tn=TypeNormaliserFactory.getNormaliser(currVal.getClass());
-        if (tn!=null) currVal=tn.normalise(currVal);
+        TypeTransformer tn=TypeNormaliserFactory.getNormaliser(currVal.getClass());
+        if (tn!=null) currVal=tn.transform(currVal);
         return currVal;
     }
 

--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
@@ -18,10 +18,14 @@ public class DbParameterAccessor {
     private int position; //zero-based index of parameter in procedure or column in table
     protected StatementExecution cs;
 
-    public static Object normaliseValue(Object currVal) throws SQLException {        
-        if (currVal==null) return null;
-        TypeTransformer tn=TypeNormaliserFactory.getNormaliser(currVal.getClass());
-        if (tn!=null) currVal=tn.transform(currVal);
+    public static Object normaliseValue(Object currVal) throws SQLException {
+        if (currVal == null) {
+            return null;
+        }
+        TypeTransformer tn = TypeNormaliserFactory.getNormaliser(currVal.getClass());
+        if (tn != null) {
+            currVal = tn.transform(currVal);
+        }
         return currVal;
     }
 

--- a/dbfit-java/core/src/main/java/dbfit/util/TypeNormaliser.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/TypeNormaliser.java
@@ -1,8 +1,0 @@
-package dbfit.util;
-
-import java.sql.SQLException;
-
-
-public interface TypeNormaliser {
-	public Object normalise(Object o) throws SQLException ;
-}

--- a/dbfit-java/core/src/main/java/dbfit/util/TypeNormaliserFactory.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/TypeNormaliserFactory.java
@@ -1,50 +1,13 @@
 package dbfit.util;
 
-import java.util.HashMap;
-import java.util.Map;
-
-@SuppressWarnings("unchecked")
 public class TypeNormaliserFactory {
-    private static Map<Class, TypeNormaliser> normalisers = new HashMap<Class, TypeNormaliser>();
+    private static TypeTransformerFactory normaliserFactory = new TypeTransformerFactory();
 
-    private static Class getCandidateIfAncestor(Class target, Class candidate) {
-        return candidate.isAssignableFrom(target) ? candidate : null;
+    public static void setNormaliser(Class<?> targetClass, TypeTransformer normaliser) {
+        normaliserFactory.setTransformer(targetClass, normaliser);
     }
 
-    private static Class getCandidateIfBetter(Class currentBest, Class nextCandidate) {
-        return currentBest.isAssignableFrom(nextCandidate) ? nextCandidate : currentBest;
-    }
-
-    private static Class findClosestAncestor(Class targetClass) {
-        Class currentBest = null;
-
-        for (Class candidate: normalisers.keySet()) {
-            if (currentBest == null) {
-                currentBest = getCandidateIfAncestor(targetClass, candidate);
-            } else {
-                currentBest = getCandidateIfBetter(currentBest, candidate);
-            }
-        }
-
-        return currentBest;
-    }
-
-    public static void setNormaliser(Class targetClass, TypeNormaliser normaliser) {
-        normalisers.put(targetClass, normaliser);
-    }
-
-    public static TypeNormaliser getNormaliser(Class targetClass) {
-        TypeNormaliser normaliser = normalisers.get(targetClass);
-
-        if (normaliser == null) {
-            Class bestCandidate = findClosestAncestor(targetClass);
-
-            if (bestCandidate != null) {
-                normaliser = normalisers.get(bestCandidate);
-                normalisers.put(targetClass, normaliser);
-            }
-        }
-
-        return normaliser;
+    public static TypeTransformer getNormaliser(Class<?> targetClass) {
+        return normaliserFactory.getTransformer(targetClass);
     }
 }

--- a/dbfit-java/core/src/main/java/dbfit/util/TypeTransformer.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/TypeTransformer.java
@@ -1,0 +1,7 @@
+package dbfit.util;
+
+import java.sql.SQLException;
+
+public interface TypeTransformer {
+    public Object transform(Object o) throws SQLException;
+}

--- a/dbfit-java/core/src/main/java/dbfit/util/TypeTransformerFactory.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/TypeTransformerFactory.java
@@ -1,0 +1,49 @@
+package dbfit.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TypeTransformerFactory {
+    private Map<Class<?>, TypeTransformer> transformers = new HashMap<Class<?>, TypeTransformer>();
+
+    private Class<?> getCandidateIfAncestor(Class<?> target, Class<?> candidate) {
+        return candidate.isAssignableFrom(target) ? candidate : null;
+    }
+
+    private Class<?> getCandidateIfBetter(Class<?> currentBest, Class<?> nextCandidate) {
+        return currentBest.isAssignableFrom(nextCandidate) ? nextCandidate : currentBest;
+    }
+
+    private Class<?> findClosestAncestor(Class<?> targetClass) {
+        Class<?> currentBest = null;
+
+        for (Class<?> candidate: transformers.keySet()) {
+            if (currentBest == null) {
+                currentBest = getCandidateIfAncestor(targetClass, candidate);
+            } else {
+                currentBest = getCandidateIfBetter(currentBest, candidate);
+            }
+        }
+
+        return currentBest;
+    }
+
+    public void setTransformer(Class<?> targetClass, TypeTransformer normaliser) {
+        transformers.put(targetClass, normaliser);
+    }
+
+    public TypeTransformer getTransformer(Class<?> targetClass) {
+        TypeTransformer normaliser = transformers.get(targetClass);
+
+        if (normaliser == null) {
+            Class<?> bestCandidate = findClosestAncestor(targetClass);
+
+            if (bestCandidate != null) {
+                normaliser = transformers.get(bestCandidate);
+                transformers.put(targetClass, normaliser);
+            }
+        }
+
+        return normaliser;
+    }
+}

--- a/dbfit-java/core/src/test/java/dbfit/util/BigDecimalNormaliserTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/BigDecimalNormaliserTest.java
@@ -32,6 +32,6 @@ public class BigDecimalNormaliserTest {
     }
 
     private BigDecimal normalise(BigDecimal val) {
-        return (BigDecimal) normaliser.normalise(val);
+        return (BigDecimal) normaliser.transform(val);
     }
 }

--- a/dbfit-java/core/src/test/java/dbfit/util/TypeTransformerFactoryTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/TypeTransformerFactoryTest.java
@@ -10,11 +10,11 @@ import java.util.AbstractList;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 
-public class TypeNormaliserFactoryTest {
-    private static TypeNormaliser createTypeNormaliserFake(final String tag) {
-        return new TypeNormaliser() {
+public class TypeTransformerFactoryTest {
+    private static TypeTransformer createTypeTransformerFake(final String tag) {
+        return new TypeTransformer() {
             @Override
-            public Object normalise(Object o) {
+            public Object transform(Object o) {
                 return null;
             }
 
@@ -29,33 +29,35 @@ public class TypeNormaliserFactoryTest {
     private final Class cmid = AbstractList.class;
     private final Class clow = ArrayList.class;
 
-    private final TypeNormaliser normaliserTop = createTypeNormaliserFake("normaliser Top");
-    private final TypeNormaliser normaliserMid = createTypeNormaliserFake("normaliser Mid");
-    private final TypeNormaliser normaliserLow = createTypeNormaliserFake("normaliser Low");
+    private final TypeTransformer normaliserTop = createTypeTransformerFake("normaliser Top");
+    private final TypeTransformer normaliserMid = createTypeTransformerFake("normaliser Mid");
+    private final TypeTransformer normaliserLow = createTypeTransformerFake("normaliser Low");
+
+    private TypeTransformerFactory ttf = new TypeTransformerFactory(); 
 
     @Before
     public void init() {
-        TypeNormaliserFactory.setNormaliser(ctop, normaliserTop);
-        TypeNormaliserFactory.setNormaliser(cmid, normaliserMid);
+        ttf.setTransformer(ctop, normaliserTop);
+        ttf.setTransformer(cmid, normaliserMid);
     }
 
     @Test
     public void normaliserLookupReturnsClosestParentIfNoExactMatch() {
-        TypeNormaliser normaliser = TypeNormaliserFactory.getNormaliser(clow);
+        TypeTransformer normaliser = ttf.getTransformer(clow);
         assertEquals(normaliserMid, normaliser);
     }
 
     @Test
     public void normaliserLookupReturnsExactMatchIfAny() {
-        TypeNormaliser normaliser = TypeNormaliserFactory.getNormaliser(cmid);
+        TypeTransformer normaliser = ttf.getTransformer(cmid);
         assertEquals(normaliserMid, normaliser);
-        normaliser = TypeNormaliserFactory.getNormaliser(ctop);
+        normaliser = ttf.getTransformer(ctop);
         assertEquals(normaliserTop, normaliser);
     }
 
     @Test
     public void normaliserLookupReturnsNullWhenNolExactMatchNorParents() {
-        TypeNormaliser normaliser = TypeNormaliserFactory.getNormaliser(String.class);
+        TypeTransformer normaliser = ttf.getTransformer(String.class);
         assertNull(normaliser);
     }
 

--- a/dbfit-java/oracle/src/main/java/dbfit/environment/OracleClobNormaliser.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/environment/OracleClobNormaliser.java
@@ -2,14 +2,14 @@ package dbfit.environment;
 
 import java.sql.SQLException;
 
-import dbfit.util.TypeNormaliser;
+import dbfit.util.TypeTransformer;
 
-public class OracleClobNormaliser implements TypeNormaliser {
+public class OracleClobNormaliser implements TypeTransformer {
 
     private static final int MAX_CLOB_LENGTH = 10000;
 
     @Override
-    public Object normalise(Object o) throws SQLException {
+    public Object transform(Object o) throws SQLException {
         if (o == null)
             return null;
         if (!(o instanceof oracle.sql.CLOB)) {

--- a/dbfit-java/oracle/src/main/java/dbfit/environment/OracleDateNormaliser.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/environment/OracleDateNormaliser.java
@@ -2,12 +2,12 @@ package dbfit.environment;
 
 import java.sql.SQLException;
 
-import dbfit.util.TypeNormaliser;
+import dbfit.util.TypeTransformer;
 
-public class OracleDateNormaliser implements TypeNormaliser {
+public class OracleDateNormaliser implements TypeTransformer {
 
     @Override
-    public Object normalise(Object o) throws SQLException {
+    public Object transform(Object o) throws SQLException {
         if (o == null)
             return null;
         if (!(o instanceof oracle.sql.DATE)) {

--- a/dbfit-java/oracle/src/main/java/dbfit/environment/OracleRefNormaliser.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/environment/OracleRefNormaliser.java
@@ -5,12 +5,12 @@ import java.sql.SQLException;
 
 import oracle.jdbc.rowset.OracleCachedRowSet;
 
-import dbfit.util.TypeNormaliser;
+import dbfit.util.TypeTransformer;
 
-public class OracleRefNormaliser implements TypeNormaliser {
+public class OracleRefNormaliser implements TypeTransformer {
 
     @Override
-    public Object normalise(Object o) throws SQLException {
+    public Object transform(Object o) throws SQLException {
         if (o == null)
             return null;
         if (!(o instanceof ResultSet))

--- a/dbfit-java/oracle/src/main/java/dbfit/environment/OracleSerialClobNormaliser.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/environment/OracleSerialClobNormaliser.java
@@ -2,14 +2,14 @@ package dbfit.environment;
 
 import java.sql.SQLException;
 
-import dbfit.util.TypeNormaliser;
+import dbfit.util.TypeTransformer;
 
-public class OracleSerialClobNormaliser implements TypeNormaliser {
+public class OracleSerialClobNormaliser implements TypeTransformer {
 
     private static final int MAX_CLOB_LENGTH = 10000;
 
     @Override
-    public Object normalise(Object o) throws SQLException {
+    public Object transform(Object o) throws SQLException {
         if (o == null)
             return null;
         if (!(o instanceof oracle.jdbc.rowset.OracleSerialClob)) {

--- a/dbfit-java/oracle/src/main/java/dbfit/environment/OracleTimestampNormaliser.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/environment/OracleTimestampNormaliser.java
@@ -2,12 +2,12 @@ package dbfit.environment;
 
 import java.sql.SQLException;
 
-import dbfit.util.TypeNormaliser;
+import dbfit.util.TypeTransformer;
 
-public class OracleTimestampNormaliser implements TypeNormaliser {
+public class OracleTimestampNormaliser implements TypeTransformer {
 
     @Override
-    public Object normalise(Object o) throws SQLException {
+    public Object transform(Object o) throws SQLException {
         if (o == null)
             return null;
         if (!(o instanceof oracle.sql.TIMESTAMP)) {

--- a/dbfit-java/oracle/src/main/java/dbfit/environment/SqlDateNormaliser.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/environment/SqlDateNormaliser.java
@@ -2,12 +2,12 @@ package dbfit.environment;
 
 import java.sql.SQLException;
 
-import dbfit.util.TypeNormaliser;
+import dbfit.util.TypeTransformer;
 
-public class SqlDateNormaliser implements TypeNormaliser {
+public class SqlDateNormaliser implements TypeTransformer {
 
     @Override
-    public Object normalise(Object o) throws SQLException {
+    public Object transform(Object o) throws SQLException {
         if (o == null)
             return null;
         if (!(o instanceof java.sql.Date)) {

--- a/dbfit-java/oracle/src/test/java/dbfit/environment/OracleClobNormaliserTest.java
+++ b/dbfit-java/oracle/src/test/java/dbfit/environment/OracleClobNormaliserTest.java
@@ -21,14 +21,14 @@ public class OracleClobNormaliserTest {
 
     @Test
     public void shouldReturnNullIfGivenNull() throws SQLException {
-        assertNull(new OracleClobNormaliser().normalise(null));
+        assertNull(new OracleClobNormaliser().transform(null));
     }
 
     @Test
     public void shouldThrowCorrectExceptionIfNotGivenACLOB() throws SQLException {
         expectedEx.expect(UnsupportedOperationException.class);
         expectedEx.expectMessage("OracleClobNormaliser cannot work with class java.lang.String");
-        new OracleClobNormaliser().normalise("Any Old Object");
+        new OracleClobNormaliser().transform("Any Old Object");
     }
 
     @Test
@@ -39,7 +39,7 @@ public class OracleClobNormaliserTest {
         expectedEx.expect(UnsupportedOperationException.class);
         expectedEx.expectMessage("Clobs larger than 10000 bytes are not supported by DBFIT");
         
-        new OracleClobNormaliser().normalise(clob);
+        new OracleClobNormaliser().transform(clob);
     }
 
     @Test
@@ -51,7 +51,7 @@ public class OracleClobNormaliserTest {
 
         // can't do this as we don't fill up the passed buffer
         //assertEquals("CLOB contents", new OracleClobNormaliser().normalise(clob));
-        new OracleClobNormaliser().normalise(clob);
+        new OracleClobNormaliser().transform(clob);
     }
 
 

--- a/dbfit-java/oracle/src/test/java/dbfit/environment/OracleDateNormaliserTest.java
+++ b/dbfit-java/oracle/src/test/java/dbfit/environment/OracleDateNormaliserTest.java
@@ -21,21 +21,21 @@ public class OracleDateNormaliserTest {
 
     @Test
     public void shouldReturnNullIfGivenNull() throws SQLException {
-        assertNull(new OracleDateNormaliser().normalise(null));
+        assertNull(new OracleDateNormaliser().transform(null));
     }
 
     @Test
     public void shouldThrowCorrectExceptionIfNotGivenAnOracleDATE() throws SQLException {
         expectedEx.expect(UnsupportedOperationException.class);
         expectedEx.expectMessage("OracleDateNormaliser cannot work with class java.lang.String");
-        new OracleDateNormaliser().normalise("Any Old Object");
+        new OracleDateNormaliser().transform("Any Old Object");
     }
 
     @Test
     public void shouldReturnContentsOfDateIfAllOkay() throws SQLException {
         DATE dt = mock(DATE.class);
         when(dt.timestampValue()).thenReturn(new Timestamp(0l));
-        assertEquals(new Timestamp(0l), new OracleDateNormaliser().normalise(dt));
+        assertEquals(new Timestamp(0l), new OracleDateNormaliser().transform(dt));
     }
 
 }

--- a/dbfit-java/oracle/src/test/java/dbfit/environment/OracleRefNormaliserTest.java
+++ b/dbfit-java/oracle/src/test/java/dbfit/environment/OracleRefNormaliserTest.java
@@ -15,14 +15,14 @@ public class OracleRefNormaliserTest {
 
     @Test
     public void shouldReturnNullIfGivenNull() throws SQLException {
-        assertNull(new OracleRefNormaliser().normalise(null));
+        assertNull(new OracleRefNormaliser().transform(null));
     }
 
     @Test
     public void shouldThrowCorrectExceptionIfNotGivenAResultSet() throws SQLException {
         expectedEx.expect(UnsupportedOperationException.class);
         expectedEx.expectMessage("OracleRefNormaliser cannot work with class java.lang.String");
-        new OracleRefNormaliser().normalise("Any Old Object");
+        new OracleRefNormaliser().transform("Any Old Object");
     }
 
 }

--- a/dbfit-java/oracle/src/test/java/dbfit/environment/OracleSerialClobNormaliserTest.java
+++ b/dbfit-java/oracle/src/test/java/dbfit/environment/OracleSerialClobNormaliserTest.java
@@ -19,14 +19,14 @@ public class OracleSerialClobNormaliserTest {
 
     @Test
     public void shouldReturnNullIfGivenNull() throws SQLException {
-        assertNull(new OracleSerialClobNormaliser().normalise(null));
+        assertNull(new OracleSerialClobNormaliser().transform(null));
     }
 
     @Test
     public void shouldThrowCorrectExceptionIfNotGivenAnOracleSerialClob() throws SQLException {
         expectedEx.expect(UnsupportedOperationException.class);
         expectedEx.expectMessage("OracleSerialClobNormaliser cannot work with class java.lang.String");
-        new OracleSerialClobNormaliser().normalise("Any Old Object");
+        new OracleSerialClobNormaliser().transform("Any Old Object");
     }
 
     @Test
@@ -37,7 +37,7 @@ public class OracleSerialClobNormaliserTest {
         expectedEx.expect(UnsupportedOperationException.class);
         expectedEx.expectMessage("Clobs larger than 10000 bytes are not supported by DBFIT");
         
-        new OracleSerialClobNormaliser().normalise(clob);
+        new OracleSerialClobNormaliser().transform(clob);
     }
 
     @Test
@@ -47,7 +47,7 @@ public class OracleSerialClobNormaliserTest {
         when(clob.length()).thenReturn(Long.valueOf("CLOB contents".length()));
         when(clob.getSubString(1l, "CLOB contents".length())).thenReturn("CLOB contents");
 
-        assertEquals("CLOB contents", new OracleSerialClobNormaliser().normalise(clob));
+        assertEquals("CLOB contents", new OracleSerialClobNormaliser().transform(clob));
     }
 
 }

--- a/dbfit-java/oracle/src/test/java/dbfit/environment/OracleTimestampNormaliserTest.java
+++ b/dbfit-java/oracle/src/test/java/dbfit/environment/OracleTimestampNormaliserTest.java
@@ -21,21 +21,21 @@ public class OracleTimestampNormaliserTest {
 
     @Test
     public void shouldReturnNullIfGivenNull() throws SQLException {
-        assertNull(new OracleTimestampNormaliser().normalise(null));
+        assertNull(new OracleTimestampNormaliser().transform(null));
     }
 
     @Test
     public void shouldThrowCorrectExceptionIfNotGivenAnOracleTIMESTAMP() throws SQLException {
         expectedEx.expect(UnsupportedOperationException.class);
         expectedEx.expectMessage("OracleTimestampNormaliser cannot work with class java.lang.String");
-        new OracleTimestampNormaliser().normalise("Any Old Object");
+        new OracleTimestampNormaliser().transform("Any Old Object");
     }
 
     @Test
     public void shouldReturnContentsOfClobIFAllOkay() throws SQLException {
         TIMESTAMP ts = mock(TIMESTAMP.class);
         when(ts.timestampValue()).thenReturn(new Timestamp(0l));
-        assertEquals(new Timestamp(0l), new OracleTimestampNormaliser().normalise(ts));
+        assertEquals(new Timestamp(0l), new OracleTimestampNormaliser().transform(ts));
     }
 
 }

--- a/dbfit-java/oracle/src/test/java/dbfit/environment/SqlDateNormaliserTest.java
+++ b/dbfit-java/oracle/src/test/java/dbfit/environment/SqlDateNormaliserTest.java
@@ -20,21 +20,21 @@ public class SqlDateNormaliserTest {
 
     @Test
     public void shouldReturnNullIfGivenNull() throws SQLException {
-        assertNull(new SqlDateNormaliser().normalise(null));
+        assertNull(new SqlDateNormaliser().transform(null));
     }
 
     @Test
     public void shouldThrowCorrectExceptionIfNotGivenADate() throws SQLException {
         expectedEx.expect(UnsupportedOperationException.class);
         expectedEx.expectMessage("SqlDateNormaliser cannot work with class java.lang.String");
-        new SqlDateNormaliser().normalise("Any Old Object");
+        new SqlDateNormaliser().transform("Any Old Object");
     }
 
     @Test
     public void shouldReturnContentsOfDateIfAllOkay() throws SQLException {
         Date dt = mock(Date.class);
         when(dt.getTime()).thenReturn(103340l);
-        assertEquals(new Timestamp(103340l), new SqlDateNormaliser().normalise(dt));
+        assertEquals(new Timestamp(103340l), new SqlDateNormaliser().transform(dt));
     }
 
 }

--- a/dbfit-java/sqlserver/src/main/java/dbfit/environment/MillisecondTimeNormaliser.java
+++ b/dbfit-java/sqlserver/src/main/java/dbfit/environment/MillisecondTimeNormaliser.java
@@ -1,13 +1,13 @@
 package dbfit.environment;
 
-import dbfit.util.TypeNormaliser;
+import dbfit.util.TypeTransformer;
 
 import java.sql.Time;
 
-public class MillisecondTimeNormaliser implements TypeNormaliser {
+public class MillisecondTimeNormaliser implements TypeTransformer {
 
     @Override
-    public Object normalise(Object o) {
+    public Object transform(Object o) {
         return (o == null) ? null : new MillisecondTime((Time) o);
     }
 }

--- a/dbfit-java/sqlserver/src/test/java/dbfit/environment/MillisecondTimeNormaliserTest.java
+++ b/dbfit-java/sqlserver/src/test/java/dbfit/environment/MillisecondTimeNormaliserTest.java
@@ -12,7 +12,7 @@ public class MillisecondTimeNormaliserTest {
 
     @Test
     public void toStringExposesTimeUpToMilliseconds() {
-        Time normalisedTime = (Time) normaliser.normalise(millisTime);
+        Time normalisedTime = (Time) normaliser.transform(millisTime);
         String[] timeParts = normalisedTime.toString().split("\\.");
 
         assertEquals("13:12:05", timeParts[0]);

--- a/dbfit-java/teradata/src/main/java/dbfit/environment/TeradataEnvironment.java
+++ b/dbfit-java/teradata/src/main/java/dbfit/environment/TeradataEnvironment.java
@@ -19,11 +19,11 @@ import java.util.regex.Pattern;
 @DatabaseEnvironment(name="Teradata", driver="com.teradata.jdbc.TeraDriver")
 public class TeradataEnvironment extends AbstractDbEnvironment {
 
-    public static class TeradataClobNormaliser implements TypeNormaliser {
+    public static class TeradataClobNormaliser implements TypeTransformer {
 
         private static final int MAX_CLOB_LENGTH = 10000;
 
-        public Object normalise(Object o) throws SQLException {
+        public Object transform(Object o) throws SQLException {
 
             if (o == null)
                 return null;
@@ -41,9 +41,9 @@ public class TeradataEnvironment extends AbstractDbEnvironment {
         }
     }
 
-    public static class TeradataPeriodNormaliser implements TypeNormaliser {
+    public static class TeradataPeriodNormaliser implements TypeTransformer {
 
-        public Object normalise(Object o) throws SQLException {
+        public Object transform(Object o) throws SQLException {
 
             if (o == null)
                 return null;


### PR DESCRIPTION
Generalise the `TypeNormaliser` mechanism - to provide a new factory class that can be used for non-global type-casting operations in support of PR #436.
