### PR TITLE
Move type transformation responsibility into TypeTransformerFactory

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
@@ -19,14 +19,11 @@ public class DbParameterAccessor {
     protected StatementExecution cs;
 
     public static Object normaliseValue(Object currVal) throws SQLException {
-        if (currVal == null) {
-            return null;
+        Object newValue = null;
+        if (currVal != null) {
+            newValue = TypeNormaliserFactory.transform(currVal);
         }
-        TypeTransformer tn = TypeNormaliserFactory.getNormaliser(currVal.getClass());
-        if (tn != null) {
-            currVal = tn.transform(currVal);
-        }
-        return currVal;
+        return newValue;
     }
 
     @Override

--- a/dbfit-java/core/src/main/java/dbfit/util/TypeNormaliserFactory.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/TypeNormaliserFactory.java
@@ -1,5 +1,7 @@
 package dbfit.util;
 
+import java.sql.SQLException;
+
 public class TypeNormaliserFactory {
     private static TypeTransformerFactory normaliserFactory = new TypeTransformerFactory();
 
@@ -7,7 +9,7 @@ public class TypeNormaliserFactory {
         normaliserFactory.setTransformer(targetClass, normaliser);
     }
 
-    public static TypeTransformer getNormaliser(Class<?> targetClass) {
-        return normaliserFactory.getTransformer(targetClass);
+    public static Object transform(Object value) throws SQLException {
+        return normaliserFactory.transform(value);
     }
 }

--- a/dbfit-java/core/src/main/java/dbfit/util/TypeTransformerFactory.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/TypeTransformerFactory.java
@@ -1,5 +1,6 @@
 package dbfit.util;
 
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +33,7 @@ public class TypeTransformerFactory {
         transformers.put(targetClass, normaliser);
     }
 
-    public TypeTransformer getTransformer(Class<?> targetClass) {
+    private TypeTransformer getTransformer(Class<?> targetClass) {
         TypeTransformer normaliser = transformers.get(targetClass);
 
         if (normaliser == null) {
@@ -45,5 +46,19 @@ public class TypeTransformerFactory {
         }
 
         return normaliser;
+    }
+
+    public Object transform(Object inValue) throws SQLException {
+        if (inValue == null) {
+            return null;
+        }
+        Object newValue = null;
+        TypeTransformer typeTrans = getTransformer(inValue.getClass());
+        if (typeTrans != null) {
+            newValue = typeTrans.transform(inValue);
+        } else {
+            newValue = inValue;
+        }
+        return newValue;
     }
 }

--- a/dbfit-java/core/src/test/java/dbfit/util/TypeTransformerFactoryTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/TypeTransformerFactoryTest.java
@@ -3,62 +3,73 @@ package dbfit.util;
 import org.junit.Test;
 import org.junit.Before;
 
-import java.util.ArrayList;
-import java.util.AbstractCollection;
-import java.util.AbstractList;
+import java.sql.SQLException;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 
 public class TypeTransformerFactoryTest {
-    private static TypeTransformer createTypeTransformerFake(final String tag) {
-        return new TypeTransformer() {
-            @Override
-            public Object transform(Object o) {
-                return null;
-            }
 
-            @Override
-            public String toString() {
-                return tag;
-            }
-        };
+    private String expectedString = new String("Top");
+    private Integer expectedInteger = new Integer(5);
+
+    private class classTop {
     }
 
-    private final Class ctop = AbstractCollection.class;
-    private final Class cmid = AbstractList.class;
-    private final Class clow = ArrayList.class;
+    private class classMid extends classTop {
+    }
 
-    private final TypeTransformer normaliserTop = createTypeTransformerFake("normaliser Top");
-    private final TypeTransformer normaliserMid = createTypeTransformerFake("normaliser Mid");
-    private final TypeTransformer normaliserLow = createTypeTransformerFake("normaliser Low");
+    private class classLow extends classMid {
+    }
+
+    private class TransformerTop implements TypeTransformer {
+        public Object transform(Object value) {
+            return expectedString;
+        }
+    }
+
+    private class TransformerMid implements TypeTransformer {
+        public Object transform(Object value) {
+            return expectedInteger;
+        }
+    }
+
+    private final Class<?> ctop = classTop.class;
+    private final Class<?> cmid = classMid.class;
+
+    private final classTop otop = new classTop();
+    private final classMid omid = new classMid();
+    private final classLow olow = new classLow();
+
+    private final TransformerTop ttop = new TransformerTop();
+    private final TransformerMid tmid = new TransformerMid();
 
     private TypeTransformerFactory ttf = new TypeTransformerFactory(); 
 
     @Before
     public void init() {
-        ttf.setTransformer(ctop, normaliserTop);
-        ttf.setTransformer(cmid, normaliserMid);
+        ttf.setTransformer(ctop, ttop);
+        ttf.setTransformer(cmid, tmid);
     }
 
     @Test
-    public void normaliserLookupReturnsClosestParentIfNoExactMatch() {
-        TypeTransformer normaliser = ttf.getTransformer(clow);
-        assertEquals(normaliserMid, normaliser);
+    public void transformerFactoryUsesClosestParentTransformerIfNoExactMatch() throws SQLException {
+        Object transformed = ttf.transform(olow);
+        assertEquals((Integer) transformed, expectedInteger);
     }
 
     @Test
-    public void normaliserLookupReturnsExactMatchIfAny() {
-        TypeTransformer normaliser = ttf.getTransformer(cmid);
-        assertEquals(normaliserMid, normaliser);
-        normaliser = ttf.getTransformer(ctop);
-        assertEquals(normaliserTop, normaliser);
+    public void transformerFactoryUsesExactMatchTransformerIfAny() throws SQLException {
+        Object transformed = ttf.transform(omid);
+        assertEquals((Integer) transformed, expectedInteger);
+        transformed = ttf.transform(otop);
+        assertEquals((String) transformed, expectedString);
     }
 
     @Test
-    public void normaliserLookupReturnsNullWhenNolExactMatchNorParents() {
-        TypeTransformer normaliser = ttf.getTransformer(String.class);
-        assertNull(normaliser);
+    public void transformerFactoryReturnsInputValueWhenNoExactMatchNorParents() throws SQLException {
+        String inputValue = "A string";
+        Object transformed = ttf.transform(inputValue);
+        assertEquals(transformed, inputValue);
     }
-
 }


### PR DESCRIPTION
Move type normalisation out of `DbParameterAccessor` into `TypeTransformerFactory` and combine with selection of the appropriate normaliser class.