### PR TITLE
Allow escaped column and table names  in postgres.

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/SimpleUpdate2/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/SimpleUpdate2/content.txt
@@ -1,0 +1,15 @@
+|insert|Users|
+|Name|Username|
+|arthur dent|adent|
+|ford prefect|fpref|
+|zaphod beeblebrox|zaphod|
+
+|update|USERS|
+|USERNAME=|NAME|
+|adent2|arthur dent|
+
+|query|select * from Users|
+|name|username|
+|arthur dent|adent2|
+|ford prefect|fpref|
+|zaphod beeblebrox|zaphod|

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/SimpleUpdate2/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/SimpleUpdate2/properties.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit/>
+	<Files/>
+	<LastModified>20080301192820</LastModified>
+	<Properties/>
+	<RecentChanges/>
+	<Refactor/>
+	<Search/>
+	<Suites></Suites>
+	<Test/>
+	<Versions/>
+	<WhereUsed/>
+	<saveId>1204399695611</saveId>
+	<ticketId>-2916918529138557195</ticketId>
+</properties>

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/SimpleUpdateEscaped/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/SimpleUpdateEscaped/content.txt
@@ -1,0 +1,15 @@
+|insert|"Pers+""+Pos"|
+|"user"|"Info""+desc"|
+|arthur dent|adent|
+|ford prefect|fpref|
+|zaphod beeblebrox|zaphod|
+
+|update|"Pers+""+Pos"|
+|"Info""+desc"=|"user"|
+|adent2|arthur dent|
+
+|query|select * from "Pers+""+Pos"|
+|"user"|"Info""+desc"|
+|arthur dent|adent2|
+|ford prefect|fpref|
+|zaphod beeblebrox|zaphod|

--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/SimpleUpdateEscaped/properties.xml
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/PostgresTests/FlowMode/SimpleUpdateEscaped/properties.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit/>
+	<Files/>
+	<LastModified>20151218192820</LastModified>
+	<Properties/>
+	<RecentChanges/>
+	<Refactor/>
+	<Search/>
+	<Suites></Suites>
+	<Test/>
+	<Versions/>
+	<WhereUsed/>
+	<saveId>1204399695611</saveId>
+	<ticketId>-2916918529138557195</ticketId>
+</properties>

--- a/dbfit-java/postgres/src/integration-test/resources/002_escapped_names.sql
+++ b/dbfit-java/postgres/src/integration-test/resources/002_escapped_names.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "Pers+""+Pos" (
+  "Pers++Pos+id" SERIAL PRIMARY KEY,
+  "user" VARCHAR(50) UNIQUE, 
+  "Info""+desc" VARCHAR(50)
+)
+;

--- a/dbfit-java/postgres/src/main/java/dbfit/environment/PostgresEnvironment.java
+++ b/dbfit-java/postgres/src/main/java/dbfit/environment/PostgresEnvironment.java
@@ -2,6 +2,7 @@ package dbfit.environment;
 
 import dbfit.annotations.DatabaseEnvironment;
 import dbfit.api.AbstractDbEnvironment;
+import dbfit.environment.postgres.NameNormaliserPostgres;
 import dbfit.util.DbParameterAccessor;
 import dbfit.util.Direction;
 import dbfit.util.NameNormaliser;
@@ -44,15 +45,14 @@ public class PostgresEnvironment extends AbstractDbEnvironment {
 
     public Map<String, DbParameterAccessor> getAllColumns(String tableOrViewName)
             throws SQLException {
-        String[] qualifiers = NameNormaliser.normaliseName(tableOrViewName)
-                .split("\\.");
+        String[] qualifiers = tableOrViewName.split("\\.");
         String qry = " select column_name, data_type, character_maximum_length "
                 + "	as direction from information_schema.columns where ";
 
         if (qualifiers.length == 2) {
-            qry += " lower(table_schema)=? and lower(table_name)=? ";
+            qry += " table_schema=? and table_name=? ";
         } else {
-            qry += " (table_schema=current_schema() and lower(table_name)=?)";
+            qry += " (table_schema=current_schema() and table_name=?)";
         }
         qry += " order by ordinal_position";
         return readIntoParams(qualifiers, qry);
@@ -63,7 +63,7 @@ public class PostgresEnvironment extends AbstractDbEnvironment {
         try (PreparedStatement dc = currentConnection.prepareStatement(query)) {
             for (int i = 0; i < queryParameters.length; i++) {
                 dc.setString(i + 1,
-                        NameNormaliser.normaliseName(queryParameters[i]));
+                        NameNormaliserPostgres.normaliseName(queryParameters[i]));
             }
             ResultSet rs = dc.executeQuery();
             Map<String, DbParameterAccessor> allParams = new HashMap<String, DbParameterAccessor>();
@@ -72,9 +72,11 @@ public class PostgresEnvironment extends AbstractDbEnvironment {
                 String paramName = rs.getString(1);
                 if (paramName == null)
                     paramName = "";
+                //fix escaping
+                paramName = paramName.replace("\"","\"\"");
                 String dataType = rs.getString(2);
                 DbParameterAccessor dbp = createDbParameterAccessor(
-                        paramName,
+                        '"' + paramName + '"',
                         Direction.INPUT, getSqlType(dataType),
                         getJavaClass(dataType), position++);
                 allParams.put(NameNormaliser.normaliseName(paramName), dbp);

--- a/dbfit-java/postgres/src/main/java/dbfit/environment/postgres/NameNormaliserPostgres.java
+++ b/dbfit-java/postgres/src/main/java/dbfit/environment/postgres/NameNormaliserPostgres.java
@@ -1,0 +1,23 @@
+package dbfit.environment.postgres;
+
+public class NameNormaliserPostgres {
+    private NameNormaliserPostgres() {
+        // utility classes should not be instanciated
+    }
+
+    private static boolean isEscaped(String name) {
+        // http://www.postgresql.org/docs/9.1/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+        return name.charAt(0) == '"' && name.charAt(name.length() - 1) == '"';
+    }
+
+    public static String normaliseName(final String name) {
+        if (name == null || name.isEmpty()) {
+            return "";
+        }
+
+        if (isEscaped(name)) {
+            return name.substring(1, name.length() - 1).replace("\"\"", "\"");
+        } 
+        return dbfit.util.NameNormaliser.normaliseName(name);
+    }
+}


### PR DESCRIPTION
Allow to have table names like public."Pos++Pers" and column names like "Pers++Pos+id"