### PR TITLE
Allow customisation of RDBMS function/procedure execution

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
@@ -1,6 +1,7 @@
 package dbfit.api;
 
 import dbfit.util.*;
+import dbfit.fixture.StatementExecution;
 import static dbfit.util.Options.OPTION_AUTO_COMMIT;
 
 import java.io.FileNotFoundException;
@@ -123,6 +124,16 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
     public DdlStatementExecution createDdlStatementExecution(String ddl)
             throws SQLException {
         return new DdlStatementExecution(getConnection().createStatement(), ddl);
+    }
+
+    @Override
+    public StatementExecution createStatementExecution(PreparedStatement statement, boolean clearParameters) {
+        return new StatementExecution(statement, clearParameters);
+    }
+
+    @Override
+    public StatementExecution createFunctionStatementExecution(PreparedStatement statement, boolean clearParameters) {
+        return new StatementExecution(statement, clearParameters);
     }
 
     protected DbParameterAccessor createDbParameterAccessor(String name, Direction direction, int sqlType, Class javaType, int position) {

--- a/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
@@ -1,5 +1,6 @@
 package dbfit.api;
 
+import dbfit.fixture.StatementExecution;
 import dbfit.util.DbParameterAccessor;
 import dbfit.util.NameNormaliser;
 import dbfit.util.DdlStatementExecution;
@@ -63,6 +64,16 @@ public interface DBEnvironment {
      */
     PreparedStatement createStatementWithBoundFixtureSymbols(TestHost th, String commandText)
             throws SQLException;
+
+    /**
+     * Create a procedure statement execution object for the given command text.
+     */
+    StatementExecution createStatementExecution(PreparedStatement statement, boolean clearParameters);
+
+    /**
+     * Create a function statement execution object for the given command text.
+     */
+    StatementExecution createFunctionStatementExecution(PreparedStatement statement, boolean clearParameters);
 
     /**
      * Create a statement execution object for the given DDL text. Bind variables
@@ -180,4 +191,3 @@ public interface DBEnvironment {
 
     DbStoredProcedureCall newStoredProcedureCall(String name, DbParameterAccessor[] accessors);
 }
-

--- a/dbfit-java/core/src/main/java/dbfit/api/DbStatement.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStatement.java
@@ -20,6 +20,6 @@ public class DbStatement {
     }
 
     public StatementExecution buildPreparedStatement() throws SQLException {
-        return new StatementExecution(environment.createStatementWithBoundFixtureSymbols(testHost, statementText), false);
+        return environment.createStatementExecution(environment.createStatementWithBoundFixtureSymbols(testHost, statementText), false);
     }
 }

--- a/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
@@ -4,6 +4,7 @@ import dbfit.fixture.StatementExecution;
 import dbfit.util.DbParameterAccessor;
 import dbfit.util.DbParameterAccessors;
 
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -51,7 +52,14 @@ public class DbStoredProcedureCall {
     }
 
     public StatementExecution toStatementExecution() throws SQLException {
-        StatementExecution cs = new StatementExecution(this.environment.getConnection().prepareCall(toSqlString()));
+        String sql = toSqlString();
+        PreparedStatement ps = environment.getConnection().prepareCall(sql);
+        StatementExecution cs;
+        if (isFunction()) {
+            cs = environment.createFunctionStatementExecution(ps, true);
+        } else {
+            cs = environment.createStatementExecution(ps, true);
+        }
         bindParametersTo(cs);
         return cs;
     }

--- a/dbfit-java/core/src/main/java/dbfit/api/DbTable.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbTable.java
@@ -30,8 +30,8 @@ public class DbTable implements DbObject {
 
     public StatementExecution buildPreparedStatement(
             DbParameterAccessor[] accessors) throws SQLException {
-        StatementExecution statement = new StatementExecution(dbEnvironment
-                .buildInsertPreparedStatement(tableOrViewName, accessors));
+        StatementExecution statement = dbEnvironment.createStatementExecution(dbEnvironment
+                .buildInsertPreparedStatement(tableOrViewName, accessors), false);
 
         for (int i = 0; i < accessors.length; i++) {
             accessors[i].bindTo(statement, i + 1);

--- a/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
@@ -5,10 +5,6 @@ import java.sql.*;
 public class StatementExecution implements AutoCloseable {
     private PreparedStatement statement;
 
-    public StatementExecution(PreparedStatement statement) {
-        this(statement, true);
-    }
-
     public StatementExecution(PreparedStatement statement, boolean clearParameters) {
         this.statement = statement;
         if (clearParameters) {

--- a/dbfit-java/core/src/main/java/dbfit/fixture/Update.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/Update.java
@@ -61,7 +61,7 @@ public class Update extends fit.Fixture {
         }
 
         StatementExecution cs =
-            new StatementExecution(environment.getConnection().prepareStatement(s.toString()));
+            environment.createStatementExecution(environment.getConnection().prepareStatement(s.toString()), true);
 
         for (int i = 0; i < updateAccessors.length; i++) {
             updateAccessors[i].bindTo(cs, i + 1);


### PR DESCRIPTION
Allow use of `StatementExecution` subtypes/customisations, with a particular view of the upcoming Informix adapter.