### PR TITLE
Prepare StatementExecution for customisations - return value index

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
@@ -3,7 +3,8 @@ package dbfit.fixture;
 import java.sql.*;
 
 public class StatementExecution implements AutoCloseable {
-    private PreparedStatement statement;
+    protected PreparedStatement statement;
+    protected int returnValueInd = -1;
 
     public StatementExecution(PreparedStatement statement, boolean clearParameters) {
         this.statement = statement;
@@ -20,7 +21,10 @@ public class StatementExecution implements AutoCloseable {
         statement.execute();
     }
 
-    public void registerOutParameter(int index, int sqlType) throws SQLException {
+    public void registerOutParameter(int index, int sqlType, boolean isReturnValue) throws SQLException {
+        if (isReturnValue) {
+            returnValueInd = index;
+        }
         convertStatementToCallable().registerOutParameter(index, sqlType);
     }
 
@@ -39,7 +43,7 @@ public class StatementExecution implements AutoCloseable {
     }
 
     //really ugly, but a hack to support mysql, because it will not execute inserts with a callable statement
-    private CallableStatement convertStatementToCallable() throws SQLException {
+    protected CallableStatement convertStatementToCallable() throws SQLException {
         if (statement instanceof CallableStatement) return (CallableStatement) statement;
         throw new SQLException("This operation requires a callable statement instead of "+ statement.getClass().getName());
     }

--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
@@ -82,7 +82,7 @@ public class DbParameterAccessor {
         this.cs=cs;
         this.index=ind;    
         if (direction != INPUT){
-            cs.registerOutParameter(ind, getSqlType());
+            cs.registerOutParameter(ind, getSqlType(), direction == RETURN_VALUE);
         }
     }
 


### PR DESCRIPTION
This change allows StatementExecution sub-classes to identify
which OUT parameter is the return value when handling the execution
of functions. This provides additional information to sub-classes
that handle function execution via a JDBC driver that handles
function values in a non-standard way.