### PR TITLE
Add missing whitespace in function execution text

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/util/sql/PreparedStatements.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/sql/PreparedStatements.java
@@ -5,12 +5,12 @@ import static dbfit.util.LangUtils.repeat;
 
 public class PreparedStatements {
     public static String buildStoredProcedureCall(String procName, int numberOfInputParameters) {
-        String inputs = join(repeat("?", numberOfInputParameters), ",");
+        String inputs = join(repeat("?", numberOfInputParameters), ", ");
         return "{ call " + procName + "(" + inputs + ")}";
     }
 
     public static String buildFunctionCall(String procName, int numberOfInputParameters) {
-        String inputs = join(repeat("?", numberOfInputParameters), ",");
-        return "{ ? =call " + procName + "(" + inputs + ")}";
+        String inputs = join(repeat("?", numberOfInputParameters), ", ");
+        return "{ ? = call " + procName + "(" + inputs + ")}";
     }
 }

--- a/dbfit-java/core/src/test/java/dbfit/api/sql/PreparedStatmentsTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/api/sql/PreparedStatmentsTest.java
@@ -8,11 +8,11 @@ import static org.junit.Assert.assertEquals;
 
 public class PreparedStatmentsTest {
     @Test public void functionWithoutParameters() {
-        assertEquals("{ ? =call func()}", buildFunctionCall("func", 0));
+        assertEquals("{ ? = call func()}", buildFunctionCall("func", 0));
     }
 
     @Test public void functionWithParameters() {
-        assertEquals("{ ? =call func(?,?)}", buildFunctionCall("func", 2));
+        assertEquals("{ ? = call func(?, ?)}", buildFunctionCall("func", 2));
     }
 
     @Test public void procedureWithoutParameters() {
@@ -20,7 +20,7 @@ public class PreparedStatmentsTest {
     }
 
     @Test public void procedureWithParameters() {
-        assertEquals("{ call storedProc(?,?)}", buildStoredProcedureCall("storedProc", 2));
+        assertEquals("{ call storedProc(?, ?)}", buildStoredProcedureCall("storedProc", 2));
     }
 }
 


### PR DESCRIPTION
This change is to enhance support function execution for pedantic
JDBC drivers that require a well formatted CALL statement and also
to improve the general formatting of the generated CALL statement.