### PR TITLE
checkstyle checks for unused and redundant imports

### DIFF
--- a/dbfit-java/config/checkstyle/checkstyle.xml
+++ b/dbfit-java/config/checkstyle/checkstyle.xml
@@ -5,5 +5,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="PackageDeclaration"/>
+    <module name="RedundantImport"/>
+    <module name="UnusedImports"/>
   </module>
 </module>


### PR DESCRIPTION
Configure checkstyle to ensure there are no unused or redundant java imports.