### PR TITLE
DBEnvironment: resolve a javadoc link

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
@@ -18,7 +18,7 @@ public interface DBEnvironment {
      * stored procedure or function name. The name may contain a schema
      * qualifier.
      * 
-     * While implementing, use {@link NameNormaliser} to make sure parameters
+     * While implementing, use {@link dbfit.util.NameNormaliser} to make sure parameters
      * are mapped properly.
      * 
      * Parameters that map to return values should have an empty string for the


### PR DESCRIPTION
A javadoc link to NameNormaliser in DBEnvironment remained unresolved after #458. Fixing it here via fully qualified class name