### PR TITLE
Set MSSQL output parameters as INPUT_OUTPUT

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/SimpleStoredProc/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/DotNetTests/SqlServerTests/FlowMode/SimpleStoredProc/content.txt
@@ -21,3 +21,21 @@ Caputure the implicit return value
 !|Execute Procedure|CalcLength_P|
 |name|str length?|?|
 |mika|4|0|
+
+SQL Server OUTPUT parameters behave like INOUT
+{{{
+CREATE PROCEDURE Increment_P
+	@counter INT OUTPUT
+AS
+BEGIN
+	SET @counter = ISNULL(@counter, 1) + 1
+END;
+}}}
+
+!|Execute Procedure|Increment_P|
+|counter?|
+|2|
+
+!|Execute Procedure|Increment_P|
+|counter|counter?|
+|7|8|

--- a/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedure.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedure.java
@@ -35,12 +35,6 @@ public class DbStoredProcedure implements DbObject {
             parameter = parameter.clone();
             parameter.setDirection(expectedDirection);
         }
-        // sql server quirk. if output parameter is used in an input column,
-        // then the param should be cloned and remapped to IN/OUT
-        if (expectedDirection!=Direction.OUTPUT && parameter.hasDirection(Direction.OUTPUT)) {
-            parameter = parameter.clone();
-            parameter.setDirection(Direction.INPUT);
-        }
         return parameter;
     }
 

--- a/dbfit-java/sqlserver/src/integration-test/resources/acceptancescripts-SqlServer.sql
+++ b/dbfit-java/sqlserver/src/integration-test/resources/acceptancescripts-SqlServer.sql
@@ -82,6 +82,22 @@ SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[Increment_P]') AND type in (N'P', N'PC'))
+BEGIN
+EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [dbo].[Increment_P]
+	@counter INT OUTPUT
+AS
+BEGIN
+	SET @counter = ISNULL(@counter, 1) + 1
+END;
+'
+END
+GO
+
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
 IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[ReturnUserTable_F]') AND type in (N'FN', N'IF', N'TF', N'FS', N'FT'))
 BEGIN
 execute dbo.sp_executesql @statement = N'-- =============================================

--- a/dbfit-java/sqlserver/src/integration-test/resources/acceptancescripts-SqlServer2000.sql
+++ b/dbfit-java/sqlserver/src/integration-test/resources/acceptancescripts-SqlServer2000.sql
@@ -24,6 +24,21 @@ END
 END
 GO
 
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[Increment_P]') AND type in (N'P', N'PC'))
+BEGIN
+EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [dbo].[Increment_P]
+	@counter INT OUTPUT
+AS
+BEGIN
+	SET @counter = ISNULL(@counter, 1) + 1
+END;
+'
+END
+GO
 
 SET ANSI_NULLS ON
 GO

--- a/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
+++ b/dbfit-java/sqlserver/src/main/java/dbfit/environment/SqlServerEnvironment.java
@@ -147,7 +147,7 @@ public class SqlServerEnvironment extends AbstractDbEnvironment {
             return RETURN_VALUE;
         }
 
-        return (isOutput == 1) ? OUTPUT : INPUT;
+        return (isOutput == 1) ? INPUT_OUTPUT : INPUT;
     }
 
     private static int getSqlType(String dataType) {


### PR DESCRIPTION
* Change `SqlServerEnvironment.getAllProcedureParameters` to handle `output` parameter as `INPUT_OUTPUT`
* Tidy up a quirk in DbStoredProcedure (it used to handle `OUTPUT` parameters as `INPUT_OUTPUT` for SQL Server) - shouldn't be needed any more