### PR TITLE
Setup MySQL Integration tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: java
 before_install:
 - "./gradlew -version"
 install: "./gradlew assemble"
-script: "./gradlew clean fastbuild"
+before_script:
+- mysql -u root -v < dbfit-java/mysql/src/integration-test/resources/create-db-mysql.sql
+script: "./gradlew clean travisbuild"
 jdk:
 - oraclejdk7
 - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -222,6 +222,11 @@ task fastbuild(dependsOn: [
     ':dbfit-java:hsqldb:integrationTest'
     ])
 
+task travisbuild(dependsOn: [
+    fastbuild,
+    ':dbfit-java:mysql:integrationTest'
+    ])
+
 if (!project.hasProperty('excludeIntegrationTests')) {
     project.ext.set('excludeIntegrationTests', '')
 }

--- a/dbfit-java/mysql/src/integration-test/resources/create-db-mysql.sql
+++ b/dbfit-java/mysql/src/integration-test/resources/create-db-mysql.sql
@@ -1,0 +1,14 @@
+create database if not exists dbfit;
+use dbfit;
+
+CREATE TABLE IF NOT EXISTS changelog (
+    change_number INTEGER NOT NULL,
+    complete_dt TIMESTAMP NOT NULL,
+    applied_by VARCHAR(100) NOT NULL,
+    description VARCHAR(500) NOT NULL,
+    CONSTRAINT Pkchangelog PRIMARY KEY (change_number)
+);
+
+create user 'dbfit_user'@'localhost' identified by 'password';
+grant all privileges on dbfit.* to 'dbfit_user'@'localhost';
+grant select on mysql.proc to 'dbfit_user'@'localhost';


### PR DESCRIPTION
* Setup MySQL test database in Travis
* Add dedicated `travisbuild` Gradle task for Travis builds (to be used instead of `fastbuild`). Include running MySQL integration tests in it