### PR TITLE
Reorg/fix DbParameterAccessors bindParameters

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
@@ -52,6 +52,10 @@ public class DbParameterAccessor {
             throw new IllegalArgumentException("Position of return value should be -1");
         }
 
+        if ((name == null) || (direction != RETURN_VALUE && name.isEmpty())) {
+            throw new IllegalArgumentException("Missing column or procedure parameter name");
+        }
+
         this.name = name;
         this.direction = direction;
         this.sqlType = sqlType;

--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessors.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessors.java
@@ -25,9 +25,6 @@ public class DbParameterAccessors {
         for (DbParameterAccessor ac : accessors) {
             int realindex = accessorNames.indexOf(ac.getName());
             ac.bindTo(statement, realindex + 1); // jdbc params are 1-based
-            if (ac.hasDirection(Direction.RETURN_VALUE)) {
-                ac.bindTo(statement, Math.abs(ac.getPosition()));
-            }
         }
     }
 


### PR DESCRIPTION
Something seems suspicious when registering RETURN_VALUE parameter:

``` java
        for (DbParameterAccessor ac : accessors) {
            int realindex = accessorNames.indexOf(ac.getName());
            ac.bindTo(statement, realindex + 1); // bindTo called 1st time
            if (ac.hasDirection(RETURN_VALUE)) {
                ac.bindTo(statement, Math.abs(ac.getPosition())); // 2nd time
            }
        }
```

* If metadata is correct: position is expected to be `-1` for return values. In such a case it would be sorted 1st, realIndex == 0 => both bindTo calls will be invoked with `ind = 1`.
* If return value position is not correct (not `-1`) - seems a broken case.

I'm considering to remove that special case with the 2nd bindTo - the 1st one should be enough.