### PR TITLE
Refactor DbParameterAccessors.getSortedAccessorNames

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessors.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessors.java
@@ -71,15 +71,11 @@ public class DbParameterAccessors {
     }
 
     public List<String> getSortedAccessorNames() {
-        List<DbParameterAccessor> newacc = new ArrayList<DbParameterAccessor>(accessors);
-        Collections.sort(newacc, new PositionComparator());
-        List<String> nameList = new ArrayList<String>();
-        String lastName = null;
-        for (DbParameterAccessor p : newacc) {
-            if (lastName != p.getName()) {
-                lastName = p.getName();
-                nameList.add(p.getName());
-            }
+        SortedSet<DbParameterAccessor> nameSet = new TreeSet<>(new PositionComparator());
+        nameSet.addAll(new ArrayList<>(accessors));
+        List<String> nameList = new ArrayList<>();
+        for (DbParameterAccessor p : nameSet) {
+            nameList.add(p.getName());
         }
         return nameList;
     }

--- a/dbfit-java/core/src/test/java/dbfit/util/DbParameterAccessorsTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/DbParameterAccessorsTest.java
@@ -1,0 +1,41 @@
+package dbfit.util;
+
+import org.junit.*;
+import static org.junit.Assert.assertEquals;
+
+import static java.util.Arrays.asList;
+
+public class DbParameterAccessorsTest {
+    private DbParameterAccessors accessors;
+
+    @Before
+    public void prepare() {
+        accessors = new DbParameterAccessors(new DbParameterAccessor[] {
+            createDummyAccessor(2),
+            createDummyAccessor(3),
+            createDummyAccessor(1),
+            createDummyAccessor(2),
+            createDummyAccessor(1)
+        });
+    }
+
+    @Test
+    public void canGetDistinctNamesSortedByPosition() {
+        assertEquals(
+                asList("dummy1", "dummy2", "dummy3"),
+                accessors.getSortedAccessorNames());
+    }
+
+    private DbParameterAccessor createDummyAccessor(int position) {
+        int sqlType = java.sql.Types.VARCHAR;
+        String inputValue = "The input value";
+        Class<?> javaType = String.class;
+        String userDefinedTypeName = "whatever";
+        TypeTransformerFactory inputTransformerFactory = null;
+
+        return new DbParameterAccessor("dummy" + position,
+            Direction.INPUT_OUTPUT,
+            sqlType, userDefinedTypeName, javaType, position,
+            inputTransformerFactory);
+    }
+}


### PR DESCRIPTION
* Use SortedSet to get sorted distinct list instead of manually
  detecting and discarding duplicates
* Discard duplicates based on position (instead of name reference
  comparison via == which might be a bit brittle)
* Add unit test