### PR TITLE
DbParameterAccessor: refactor clone

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
@@ -30,13 +30,19 @@ public class DbParameterAccessor {
         return currVal;
     }
 
+    /*
+     * Create an exact copy of this object. Normally this should be
+     * overridden in favour of the clone template method
+     */
+    protected DbParameterAccessor copy() {
+        return new DbParameterAccessor(name, direction,
+                sqlType, javaType, position, dbfitToJdbcTransformerFactory);
+    }
+
     @Override
     public DbParameterAccessor clone() {
-        DbParameterAccessor copy = new DbParameterAccessor(name, direction,
-                sqlType, javaType, position, dbfitToJdbcTransformerFactory);
-
+        DbParameterAccessor copy = copy();
         copy.cs = null;
-
         return copy;
     }
 

--- a/dbfit-java/oracle/src/main/java/dbfit/util/OracleDbParameterAccessor.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/util/OracleDbParameterAccessor.java
@@ -22,13 +22,9 @@ public class OracleDbParameterAccessor extends DbParameterAccessor {
     }
 
     @Override
-    public OracleDbParameterAccessor clone() {
-        OracleDbParameterAccessor copy = new OracleDbParameterAccessor(
+    protected DbParameterAccessor copy() {
+        return new OracleDbParameterAccessor(
                 getName(), getDirection(), getSqlType(), getJavaType(), getPosition(),
                 getDbfitToJdbcTransformerFactory(), originalTypeName, getUserDefinedTypeName());
-        copy.cs = null;
-
-        return copy;
     }
 }
-


### PR DESCRIPTION
Refactor `clone()` in order to reduce the need of referencing internals (e.g the statement) by inheritants.

Implemented by introducing protected exact-copy `copy()` and making `clone()` a template method doing `clone() + finishing steps`