### PR TITLE
PreparedStatementsTest: fix name typo and package

### DIFF
--- a/dbfit-java/core/src/test/java/dbfit/util/sql/PreparedStatementsTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/sql/PreparedStatementsTest.java
@@ -1,4 +1,4 @@
-package dbfit.api.sql;
+package dbfit.util.sql;
 
 import org.junit.Test;
 
@@ -6,7 +6,7 @@ import static dbfit.util.sql.PreparedStatements.buildFunctionCall;
 import static dbfit.util.sql.PreparedStatements.buildStoredProcedureCall;
 import static org.junit.Assert.assertEquals;
 
-public class PreparedStatmentsTest {
+public class PreparedStatementsTest {
     @Test public void functionWithoutParameters() {
         assertEquals("{ ? = call func()}", buildFunctionCall("func", 0));
     }


### PR DESCRIPTION
Fix a typo in `PreparedStatementsTest` name and move it to the correct package and related folder (in alignment with `PreparedStatements.java`)