### PR TITLE
Remove clearParameters from StatementExecution c-tor

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
@@ -127,13 +127,13 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
     }
 
     @Override
-    public StatementExecution createStatementExecution(PreparedStatement statement, boolean clearParameters) {
-        return new StatementExecution(statement, clearParameters);
+    public StatementExecution createStatementExecution(PreparedStatement statement) {
+        return new StatementExecution(statement);
     }
 
     @Override
-    public StatementExecution createFunctionStatementExecution(PreparedStatement statement, boolean clearParameters) {
-        return new StatementExecution(statement, clearParameters);
+    public StatementExecution createFunctionStatementExecution(PreparedStatement statement) {
+        return new StatementExecution(statement);
     }
 
     protected DbParameterAccessor createDbParameterAccessor(String name, Direction direction, int sqlType, Class javaType, int position) {

--- a/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DBEnvironment.java
@@ -67,12 +67,12 @@ public interface DBEnvironment {
     /**
      * Create a procedure statement execution object for the given command text.
      */
-    StatementExecution createStatementExecution(PreparedStatement statement, boolean clearParameters);
+    StatementExecution createStatementExecution(PreparedStatement statement);
 
     /**
      * Create a function statement execution object for the given command text.
      */
-    StatementExecution createFunctionStatementExecution(PreparedStatement statement, boolean clearParameters);
+    StatementExecution createFunctionStatementExecution(PreparedStatement statement);
 
     /**
      * Create a statement execution object for the given DDL text. Bind variables

--- a/dbfit-java/core/src/main/java/dbfit/api/DbStatement.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStatement.java
@@ -20,6 +20,6 @@ public class DbStatement {
     }
 
     public StatementExecution buildPreparedStatement() throws SQLException {
-        return environment.createStatementExecution(environment.createStatementWithBoundFixtureSymbols(testHost, statementText), false);
+        return environment.createStatementExecution(environment.createStatementWithBoundFixtureSymbols(testHost, statementText));
     }
 }

--- a/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
@@ -56,9 +56,9 @@ public class DbStoredProcedureCall {
         PreparedStatement ps = environment.getConnection().prepareCall(sql);
         StatementExecution cs;
         if (isFunction()) {
-            cs = environment.createFunctionStatementExecution(ps, true);
+            cs = environment.createFunctionStatementExecution(ps);
         } else {
-            cs = environment.createStatementExecution(ps, true);
+            cs = environment.createStatementExecution(ps);
         }
         bindParametersTo(cs);
         return cs;

--- a/dbfit-java/core/src/main/java/dbfit/api/DbTable.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbTable.java
@@ -31,7 +31,7 @@ public class DbTable implements DbObject {
     public StatementExecution buildPreparedStatement(
             DbParameterAccessor[] accessors) throws SQLException {
         StatementExecution statement = dbEnvironment.createStatementExecution(dbEnvironment
-                .buildInsertPreparedStatement(tableOrViewName, accessors), false);
+                .buildInsertPreparedStatement(tableOrViewName, accessors));
 
         for (int i = 0; i < accessors.length; i++) {
             accessors[i].bindTo(statement, i + 1);

--- a/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
@@ -6,15 +6,8 @@ public class StatementExecution implements AutoCloseable {
     protected PreparedStatement statement;
     protected int returnValueInd = -1;
 
-    public StatementExecution(PreparedStatement statement, boolean clearParameters) {
+    public StatementExecution(PreparedStatement statement) {
         this.statement = statement;
-        if (clearParameters) {
-            try {
-                statement.clearParameters();
-            } catch (SQLException e) {
-                throw new RuntimeException("Exception while clearing parameters on PreparedStatement", e);
-            }
-        }
     }
 
     public void run() throws SQLException {

--- a/dbfit-java/core/src/main/java/dbfit/fixture/Update.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/Update.java
@@ -61,7 +61,7 @@ public class Update extends fit.Fixture {
         }
 
         StatementExecution cs =
-            environment.createStatementExecution(environment.getConnection().prepareStatement(s.toString()), true);
+            environment.createStatementExecution(environment.getConnection().prepareStatement(s.toString()));
 
         for (int i = 0; i < updateAccessors.length; i++) {
             updateAccessors[i].bindTo(cs, i + 1);

--- a/dbfit-java/informix/src/main/java/dbfit/environment/InformixEnvironment.java
+++ b/dbfit-java/informix/src/main/java/dbfit/environment/InformixEnvironment.java
@@ -292,7 +292,7 @@ public class InformixEnvironment extends AbstractDbEnvironment {
     }
 
     @Override
-    public StatementExecution createFunctionStatementExecution(PreparedStatement statement, boolean clearParameters) {
-        return new InformixFunctionStatementExecution(statement, clearParameters);
+    public StatementExecution createFunctionStatementExecution(PreparedStatement statement) {
+        return new InformixFunctionStatementExecution(statement);
     }
 }

--- a/dbfit-java/informix/src/main/java/dbfit/environment/InformixFunctionStatementExecution.java
+++ b/dbfit-java/informix/src/main/java/dbfit/environment/InformixFunctionStatementExecution.java
@@ -7,8 +7,8 @@ import dbfit.fixture.StatementExecution;
 public class InformixFunctionStatementExecution extends StatementExecution {
     private Object returnValue = null;
 
-    public InformixFunctionStatementExecution(PreparedStatement statement, boolean clearParameters) {
-        super(statement, clearParameters);
+    public InformixFunctionStatementExecution(PreparedStatement statement) {
+        super(statement);
     }
 
     @Override


### PR DESCRIPTION
Remove `clearParameters` parameter from `StatementExecution` and related factory methods. Leave the behavior of `clearParameters = *false*`.

In the existing code all cases with `clearParameters=true` the passed statement is clean anyway (it doesn't  ave any parameters) - so explicit `clearParameters` seems superfluous.

If in future a need for explicit `cleanParameters` emerges: it could be rather implemented as a `StatementExecution` method.