### PR TITLE
Refactor DbStoredProcedureCall, PreparedStatements

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
@@ -6,7 +6,6 @@ import dbfit.util.DbParameterAccessors;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.List;
 
 import static dbfit.util.sql.PreparedStatements.buildFunctionCall;
 import static dbfit.util.sql.PreparedStatements.buildStoredProcedureCall;
@@ -33,17 +32,15 @@ public class DbStoredProcedureCall {
         return new DbParameterAccessors(accessors).containsReturnValue();
     }
 
-    public int getNumberOfInputParameters() {
-        List<String> accessorNames = new DbParameterAccessors(getAccessors()).getSortedAccessorNames();
-        int numberOfAccessors = accessorNames.size();
-        return isFunction() ? numberOfAccessors - 1 : numberOfAccessors;
+    private int getNumberOfParameters() {
+        return new DbParameterAccessors(getAccessors()).getNumberOfParameters();
     }
 
     public String toSqlString() {
         if (isFunction()) {
-            return buildFunctionCall(getName(), getNumberOfInputParameters());
+            return buildFunctionCall(getName(), getNumberOfParameters());
         } else {
-            return buildStoredProcedureCall(getName(), getNumberOfInputParameters());
+            return buildStoredProcedureCall(getName(), getNumberOfParameters());
         }
     }
 

--- a/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/DbStoredProcedureCall.java
@@ -3,37 +3,37 @@ package dbfit.api;
 import dbfit.fixture.StatementExecution;
 import dbfit.util.DbParameterAccessor;
 import dbfit.util.DbParameterAccessors;
+import static dbfit.util.sql.PreparedStatements.buildFunctionCall;
+import static dbfit.util.sql.PreparedStatements.buildStoredProcedureCall;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import static dbfit.util.sql.PreparedStatements.buildFunctionCall;
-import static dbfit.util.sql.PreparedStatements.buildStoredProcedureCall;
-
 public class DbStoredProcedureCall {
-    private DBEnvironment environment;
-    private String name;
-    private DbParameterAccessor[] accessors;
+    private final DBEnvironment environment;
+    private final String name;
+    private final DbParameterAccessors accessors;
 
     public DbStoredProcedureCall(DBEnvironment environment, String name, DbParameterAccessor[] accessors) {
         this.environment = environment;
         this.name = name;
-        this.accessors = accessors;
+        this.accessors = new DbParameterAccessors(accessors);
     }
+
     public String getName() {
         return name;
     }
 
-    public DbParameterAccessor[] getAccessors() {
+    protected DbParameterAccessors getAccessors() {
         return accessors;
     }
 
     public boolean isFunction() {
-        return new DbParameterAccessors(accessors).containsReturnValue();
+        return getAccessors().containsReturnValue();
     }
 
     private int getNumberOfParameters() {
-        return new DbParameterAccessors(getAccessors()).getNumberOfParameters();
+        return getAccessors().getNumberOfParameters();
     }
 
     public String toSqlString() {
@@ -45,7 +45,7 @@ public class DbStoredProcedureCall {
     }
 
     void bindParametersTo(StatementExecution cs) throws SQLException {
-        new DbParameterAccessors(getAccessors()).bindParameters(cs);
+        getAccessors().bindParameters(cs);
     }
 
     public StatementExecution toStatementExecution() throws SQLException {

--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessors.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessors.java
@@ -9,7 +9,7 @@ import static dbfit.util.Direction.INPUT;
 import static dbfit.util.Direction.OUTPUT;
 import static dbfit.util.Direction.RETURN_VALUE;
 
-public class DbParameterAccessors {
+public class DbParameterAccessors implements Iterable<DbParameterAccessor> {
     private List<DbParameterAccessor> accessors;
 
     public DbParameterAccessors(DbParameterAccessor[] accessors) {
@@ -30,6 +30,11 @@ public class DbParameterAccessors {
 
     public DbParameterAccessor[] toArray() {
         return accessors.toArray(new DbParameterAccessor[]{});
+    }
+
+    @Override
+    public Iterator<DbParameterAccessor> iterator() {
+        return accessors.iterator();
     }
 
     public void add(DbParameterAccessor accessor) {

--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessors.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessors.java
@@ -80,6 +80,11 @@ public class DbParameterAccessors {
         return nameList;
     }
 
+    // number of distinct parameters (in, out, inout and return value)
+    public int getNumberOfParameters() {
+        return getSortedAccessorNames().size();
+    }
+
     public boolean containsReturnValue() {
         for (DbParameterAccessor ac : accessors) {
             if (ac.isReturnValueAccessor()) {

--- a/dbfit-java/core/src/main/java/dbfit/util/sql/PreparedStatements.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/sql/PreparedStatements.java
@@ -4,13 +4,15 @@ import static dbfit.util.LangUtils.join;
 import static dbfit.util.LangUtils.repeat;
 
 public class PreparedStatements {
-    public static String buildStoredProcedureCall(String procName, int numberOfInputParameters) {
-        String inputs = join(repeat("?", numberOfInputParameters), ", ");
-        return "{ call " + procName + "(" + inputs + ")}";
+    private static String buildParamList(int numberOfParameters) {
+        return join(repeat("?", numberOfParameters), ", ");
     }
 
-    public static String buildFunctionCall(String procName, int numberOfInputParameters) {
-        String inputs = join(repeat("?", numberOfInputParameters), ", ");
-        return "{ ? = call " + procName + "(" + inputs + ")}";
+    public static String buildStoredProcedureCall(String procName, int numberOfPararameters) {
+        return "{ call " + procName + "(" + buildParamList(numberOfPararameters) + ")}";
+    }
+
+    public static String buildFunctionCall(String procName, int numberOfParameters) {
+        return "{ ? = call " + procName + "(" + buildParamList(numberOfParameters - 1) + ")}";
     }
 }

--- a/dbfit-java/core/src/test/java/dbfit/util/sql/PreparedStatementsTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/sql/PreparedStatementsTest.java
@@ -8,11 +8,11 @@ import static org.junit.Assert.assertEquals;
 
 public class PreparedStatementsTest {
     @Test public void functionWithoutParameters() {
-        assertEquals("{ ? = call func()}", buildFunctionCall("func", 0));
+        assertEquals("{ ? = call func()}", buildFunctionCall("func", 1));
     }
 
     @Test public void functionWithParameters() {
-        assertEquals("{ ? = call func(?, ?)}", buildFunctionCall("func", 2));
+        assertEquals("{ ? = call func(?, ?)}", buildFunctionCall("func", 3));
     }
 
     @Test public void procedureWithoutParameters() {

--- a/dbfit-java/oracle/src/main/java/dbfit/environment/OracleStoredProcedureCall.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/environment/OracleStoredProcedureCall.java
@@ -3,7 +3,6 @@ package dbfit.environment;
 import dbfit.api.DBEnvironment;
 import dbfit.api.DbStoredProcedureCall;
 import dbfit.util.DbParameterAccessor;
-import dbfit.util.DbParameterAccessors;
 import dbfit.util.OracleDbParameterAccessor;
 import dbfit.util.oracle.OracleBooleanSpCommand;
 import dbfit.util.oracle.OracleSpParameter;
@@ -44,10 +43,9 @@ public class OracleStoredProcedureCall extends DbStoredProcedureCall {
         }
     }
 
-    private Map<String, DbParameterAccessor> getAccessorsMap(
-            DbParameterAccessor[] accessors) {
+    private Map<String, DbParameterAccessor> getAccessorsMap() {
         Map<String, DbParameterAccessor> map = new HashMap<String, DbParameterAccessor>();
-        for (DbParameterAccessor ac: accessors) {
+        for (DbParameterAccessor ac: getAccessors()) {
             addAccessor(map, ac);
         }
 
@@ -75,12 +73,11 @@ public class OracleStoredProcedureCall extends DbStoredProcedureCall {
     }
 
     private SpParamsSpec initSpParams() {
-        List<String> accessorNames = new DbParameterAccessors(getAccessors()).getSortedAccessorNames();
-        Map<String, DbParameterAccessor> accessorsMap = getAccessorsMap(getAccessors());
+        Map<String, DbParameterAccessor> accessorsMap = getAccessorsMap();
 
         SpParamsSpec params = new SpParamsSpec();
 
-        for (String acName: accessorNames) {
+        for (String acName: getAccessors().getSortedAccessorNames()) {
             OracleSpParameter param = makeOracleSpParameter(accessorsMap.get(acName));
             params.add(param);
         }


### PR DESCRIPTION
* PreparedStatements: change semantics and name of the `number of parameters` (previous name was a bit misleading) - in order to align with the existing code base where return value is treated as parameter
* DbStoredProcedureCall: use `DbParameterAccessors` DbFit class instead of DbParameterAccessor[] plain array
* Simplify the code, remove some duplication