### PR TITLE
Move static normailseValue to new ValueNormaliser

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/fixture/Inspect.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/Inspect.java
@@ -14,6 +14,7 @@ import java.sql.SQLException;
 import java.util.Map;
 
 import static dbfit.util.Direction.*;
+import static dbfit.util.ValueNormaliser.normaliseValue;
 
 public class Inspect extends fit.Fixture {
     private DBEnvironment environment;
@@ -96,7 +97,7 @@ public class Inspect extends fit.Fixture {
         Parse prevCell = null;
         for (int i = 0; i < rsmd.getColumnCount(); i++) {
             Object value = rs.getObject(i + 1);
-            value = DbParameterAccessor.normaliseValue(value);
+            value = normaliseValue(value);
             Parse cell = new Parse("td",
                 Fixture.gray(value == null ? "null" : value.toString()), null, null);
             if (prevCell == null) {

--- a/dbfit-java/core/src/main/java/dbfit/util/DataRow.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DataRow.java
@@ -1,7 +1,7 @@
 package dbfit.util;
 
 import static dbfit.util.NameNormaliser.normaliseName;
-import static dbfit.util.DbParameterAccessor.normaliseValue;
+import static dbfit.util.ValueNormaliser.normaliseValue;
 
 import java.util.*;
 import java.sql.*;

--- a/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DbParameterAccessor.java
@@ -2,6 +2,7 @@ package dbfit.util;
 
 import dbfit.fixture.StatementExecution;
 import static dbfit.util.Direction.*;
+import static dbfit.util.ValueNormaliser.normaliseValue;
 
 import java.lang.reflect.InvocationTargetException;
 import java.sql.SQLException;
@@ -17,18 +18,6 @@ public class DbParameterAccessor {
     private int position; // zero-based index of parameter in procedure (-1 for ret value) or column in table
     protected StatementExecution cs;
     private TypeTransformerFactory dbfitToJdbcTransformerFactory;
-
-    public static Object normaliseValue(Object currVal) throws SQLException {
-        if (currVal == null) {
-            return null;
-        }
-
-        TypeTransformer tn = TypeNormaliserFactory.getNormaliser(currVal.getClass());
-        if (tn != null) {
-            currVal = tn.transform(currVal);
-        }
-        return currVal;
-    }
 
     /*
      * Create an exact copy of this object. Normally this should be

--- a/dbfit-java/core/src/main/java/dbfit/util/ValueNormaliser.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/ValueNormaliser.java
@@ -1,0 +1,17 @@
+package dbfit.util;
+
+import java.sql.SQLException;
+
+public class ValueNormaliser {
+
+    public static Object normaliseValue(Object value) throws SQLException {
+        if (value == null) {
+            return null;
+        }
+
+        TypeTransformer transformer =
+            TypeNormaliserFactory.getNormaliser(value.getClass());
+
+        return (transformer == null) ? value : transformer.transform(value);
+    }
+}

--- a/dbfit-java/core/src/test/java/dbfit/util/ValueNormaliserTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/ValueNormaliserTest.java
@@ -1,0 +1,43 @@
+package dbfit.util;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.sql.SQLException;
+
+public class ValueNormaliserTest {
+
+    @Before
+    public void prepare() {
+        TypeNormaliserFactory.setNormaliser(String.class, new TypeTransformer() {
+            @Override
+            public Object transform(Object o) {
+                return o.toString().toUpperCase();
+            }
+        });
+    }
+
+    @After
+    public void cleanup() {
+        TypeNormaliserFactory.setNormaliser(String.class, null);
+    }
+
+    @Test
+    public void canNormaliseValuesForRegisteredTypes() throws SQLException {
+        assertEquals("TEST", ValueNormaliser.normaliseValue("test"));
+    }
+
+    @Test
+    public void normalisedNullIsNull() throws SQLException {
+        assertNull(ValueNormaliser.normaliseValue(null));
+    }
+
+    @Test
+    public void normaliseValueIsIdentityForUnregisteredTypes() throws SQLException {
+        Integer value = Integer.valueOf(13);
+        assertEquals(value, ValueNormaliser.normaliseValue(value));
+    }
+}


### PR DESCRIPTION
Refactoring: move `normaliseValue` from `DbParameterAccessor` to to a separate class. (The current implementation is not related to params accessors nor is a good idea to hold static stuff there).