### PR TITLE
Bump up FitNesse version to 20160515

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    fitNesseVersion = '20151230'
+    fitNesseVersion = '20160515'
     mockitoVersion = '1.10.19'
     junitVersion = '4.12'
 }


### PR DESCRIPTION
Since version 20160515 FitNesse requires Java 7+ (Java 6 is not supported any more) - i.e. JVM requirements are like DbFit ones. Related topic #411