### PR TITLE
Bump up Mockito to 2.2.2

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -1,6 +1,6 @@
 ext {
     fitNesseVersion = '20160618'
-    mockitoVersion = '1.10.19'
+    mockitoVersion = '2.2.2'
     junitVersion = '4.12'
 }
 

--- a/dbfit-java/core/src/test/java/dbfit/diff/DataRowDiffTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/diff/DataRowDiffTest.java
@@ -118,6 +118,6 @@ public class DataRowDiffTest {
     }
 
     private DataCell anyDataCell() {
-        return org.mockito.Matchers.any(DataCell.class);
+        return org.mockito.ArgumentMatchers.any();
     }
 }

--- a/dbfit-java/core/src/test/java/dbfit/diff/DataTableDiffTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/diff/DataTableDiffTest.java
@@ -129,6 +129,6 @@ public class DataTableDiffTest {
     }
 
     private DataRow anyDataRow() {
-        return org.mockito.Matchers.any(DataRow.class);
+        return org.mockito.ArgumentMatchers.any();
     }
 }

--- a/dbfit-java/core/src/test/java/dbfit/util/DataCellTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/DataCellTest.java
@@ -23,7 +23,6 @@ public class DataCellTest {
     @Before
     public void prepare() {
         when(row.get("n")).thenReturn("2");
-        when(row.get("2n")).thenReturn("4");
 
         when(row2.get("n")).thenReturn("1");
         when(row2.get("2n")).thenReturn("2");


### PR DESCRIPTION
Bump up Mockito to 2.2.2.

Required change of a few tests due to API changes for any() matchers and requirement for removing unused stubbing.