### PR TITLE
Exclude test VM optional installation DB types from default integrationBuild task

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+excludeIntegrationTests=db2,informix,netezza,oracle,sqlserver,teradata


### PR DESCRIPTION
Exclude test VM optional installation DB types from default integrationBuild task