### PR TITLE
test_vm: fix postgres changelog table creation

### DIFF
--- a/test_vm/vendor/cookbooks/dbfit_test/recipes/postgres.rb
+++ b/test_vm/vendor/cookbooks/dbfit_test/recipes/postgres.rb
@@ -32,6 +32,7 @@ end
 # needed to support DbDeploy
 postgresql_database 'dbfit.changelog' do
   connection postgresql_connection_info
+  database_name 'dbfit'
   sql "CREATE TABLE IF NOT EXISTS changelog (
          change_number INTEGER CONSTRAINT Pkchangelog PRIMARY KEY,
          complete_dt TIMESTAMP NOT NULL,


### PR DESCRIPTION
Use explicit database_name parameter when creating postgres `changelog` table. The issue has been introduced with 904ced727 (#513) - the resource cloning removal.