### PR TITLE
Oracle jdbc 12 support

### DIFF
--- a/dbfit-java/oracle/src/main/java/dbfit/environment/OracleEnvironment.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/environment/OracleEnvironment.java
@@ -229,8 +229,7 @@ public class OracleEnvironment extends AbstractDbEnvironment {
         TypeNormaliserFactory.setNormaliser(java.sql.Date.class,
                 new SqlDateNormaliser());
         try {
-            TypeNormaliserFactory.setNormaliser(
-                    Class.forName("oracle.jdbc.driver.OracleResultSetImpl"),
+            TypeNormaliserFactory.setNormaliser(java.sql.ResultSet.class,
                     new OracleRefNormaliser());
         } catch (Exception e) {
             throw new Error("Cannot initialise oracle rowset", e);


### PR DESCRIPTION
Drop reference to an internal oracle class oracle.jdbc.driver.OracleResultSetImpl which is not present in latest jdbc version any more. Use standard java.sql.ResultSet instead.

resolves #164 