### PR TITLE
Add RecentChanges.wiki to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ FitNesseRoot/files/testResults
 FitNesseRoot/files/testProgress
 FitNesseRoot/update*
 FitNesseRoot/RecentChanges
+FitNesseRoot/RecentChanges.wiki
 [0-9]*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9].zip
 [A-Za-z0-9]*-[0-9]*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9].zip
 


### PR DESCRIPTION
The recent FitNesse version creates `RecentChanges` file with `.wiki` extension.