### PR TITLE
Hidden symbol getter/setter support

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/CoreTests/CommonSuite/Symbols.wiki
+++ b/FitNesseRoot/DbFit/AcceptanceTests/CoreTests/CommonSuite/Symbols.wiki
@@ -1,0 +1,79 @@
+---
+Test
+---
+!|Execute Ddl|create table testtbl(id int, val int)|
+
+!|Insert|testtbl|
+|id     |val    |
+|1      |101    |
+|2      |102    |
+
+!3 Symbols in Query
+
+# Assigning
+!|Query|select id, val from testtbl|
+|id|val?                       |
+|1 |>>v1                       |
+|2 |>>>v2                      |
+
+# Query - symbol in key columns
+!|Query|select val from testtbl|
+|val                           |
+|<<v1                          |
+|<<<v2                         |
+
+# Query - symbol in non key columns
+!|Query|select id, val from testtbl|
+|id|val?                           |
+|1 |<<<v1                          |
+|2 |<<v2                           |
+
+!3 symbols in Update
+
+|Update|testtbl|
+|val=  |id     |
+|<<v2  |1      |
+|<<<v1 |2      |
+
+!|Query|select id, val from testtbl|
+|id|val?                           |
+|2 |<<<v1                          |
+|1 |<<v2                           |
+
+!3 Set Parameter
+
+!|Set Parameter|x3|103|
+
+!|Set Parameter|x4|104|
+
+!|Set Parameter|v3|<<x3|
+
+!|Set Parameter|v4|<<<x4|
+
+!3 Insert
+
+!|Insert|testtbl|
+|id     |val    |
+|3      |<<v3   |
+|4      |<<<v4  |
+
+!|Query|select id, val from testtbl where id in (3, 4)|
+|id|val? |
+|3 |103  |
+|4 |104  |
+
+!3 Stored Procedures
+
+!|Execute Procedure    |CalcLength  |
+|name                  |str length? |
+|abcd                  |>>len4      |
+|abc1234               |>>>len7     |
+|<<v3                  |3           |
+
+!|Execute Procedure    |CalcLength  |
+|name                  |str length? |
+|abcd                  |<<len4      |
+|abc1234               |<<<len7     |
+
+# Tear Down
+!|Execute Ddl|drop table testtbl|

--- a/dbfit-java/core/src/main/java/dbfit/util/CellHelper.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/CellHelper.java
@@ -1,0 +1,17 @@
+package dbfit.util;
+
+import fit.Fixture;
+import fit.Parse;
+
+class CellHelper {
+
+    static void appendObjectValue(Parse cell, Object value) {
+        cell.addToBody(Fixture.gray("= " + String.valueOf(value)));
+    }
+
+    static void appendObjectValue(Parse cell, Object value, boolean isVisible) {
+        if (isVisible) {
+            appendObjectValue(cell, value);
+        }
+    }
+}

--- a/dbfit-java/core/src/main/java/dbfit/util/SymbolAccessQueryBinding.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/SymbolAccessQueryBinding.java
@@ -4,22 +4,22 @@ import fit.Binding;
 import fit.Fixture;
 import fit.Parse;
 
+import static dbfit.util.CellHelper.appendObjectValue;
+
 public class SymbolAccessQueryBinding extends Binding.QueryBinding {
+
     public void doCell(Fixture fixture, Parse cell) {
         ContentOfTableCell content = new ContentOfTableCell(cell.text());
         try {
             if (content.isSymbolSetter()) {
                 Object actual = this.adapter.get();
                 dbfit.util.SymbolUtil.setSymbol(content.text(), actual);
-                if (!content.isSymbolHidden()) {
-                    cell.addToBody(Fixture.gray("= " + String.valueOf(actual)));
-                }
+                appendObjectValue(cell, actual, !content.isSymbolHidden());
                 // fixture.ignore(cell);
             } else if (content.isSymbolGetter()) {
                 Object actual = this.adapter.get();
                 Object expected = this.adapter.parse(content.text());
-                String displayValue = content.isSymbolHidden() ? "" : ("= " + String.valueOf(expected));
-                cell.addToBody(Fixture.gray(displayValue));
+                appendObjectValue(cell, expected, !content.isSymbolHidden());
 
                 if (adapter.equals(actual, expected)) {
                     fixture.right(cell);
@@ -30,7 +30,7 @@ public class SymbolAccessQueryBinding extends Binding.QueryBinding {
                 //expect failing comparison
                 Object actual = this.adapter.get();
                 String expectedVal = content.getExpectedFailureValue();
-                cell.addToBody(Fixture.gray("= " + String.valueOf(actual)));
+                appendObjectValue(cell, actual);
 
                 if (adapter.equals(actual, adapter.parse(expectedVal))) {
                     fixture.wrong(cell);

--- a/dbfit-java/core/src/main/java/dbfit/util/SymbolAccessQueryBinding.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/SymbolAccessQueryBinding.java
@@ -11,12 +11,15 @@ public class SymbolAccessQueryBinding extends Binding.QueryBinding {
             if (content.isSymbolSetter()) {
                 Object actual = this.adapter.get();
                 dbfit.util.SymbolUtil.setSymbol(content.text(), actual);
-                cell.addToBody(Fixture.gray("= " + String.valueOf(actual)));
+                if (!content.isSymbolHidden()) {
+                    cell.addToBody(Fixture.gray("= " + String.valueOf(actual)));
+                }
                 // fixture.ignore(cell);
             } else if (content.isSymbolGetter()) {
                 Object actual = this.adapter.get();
                 Object expected = this.adapter.parse(content.text());
-                cell.addToBody(Fixture.gray("= " + String.valueOf(expected)));
+                String displayValue = content.isSymbolHidden() ? "" : ("= " + String.valueOf(expected));
+                cell.addToBody(Fixture.gray(displayValue));
 
                 if (adapter.equals(actual, expected)) {
                     fixture.right(cell);
@@ -59,6 +62,10 @@ public class SymbolAccessQueryBinding extends Binding.QueryBinding {
 
         public boolean isSymbolGetter() {
             return SymbolUtil.isSymbolGetter(content);
+        }
+
+        public boolean isSymbolHidden() {
+            return SymbolUtil.isSymbolHidden(content);
         }
 
         private boolean isExpectingInequality() {

--- a/dbfit-java/core/src/main/java/dbfit/util/SymbolAccessSetBinding.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/SymbolAccessSetBinding.java
@@ -6,6 +6,7 @@ import fit.Parse;
 
 import static dbfit.util.SymbolUtil.isSymbolGetter;
 import static dbfit.util.SymbolUtil.isSymbolHidden;
+import static dbfit.util.CellHelper.appendObjectValue;
 
 public class SymbolAccessSetBinding extends Binding.SetBinding {
 
@@ -14,9 +15,7 @@ public class SymbolAccessSetBinding extends Binding.SetBinding {
         String text = cell.text();
         if (isSymbolGetter(text)) {
             Object value = dbfit.util.SymbolUtil.getSymbol(text);
-            if (!isSymbolHidden(text)) {
-                cell.addToBody(Fixture.gray(" = " + String.valueOf(value)));
-            }
+            appendObjectValue(cell, value, !isSymbolHidden(text));
             adapter.set(value);
             return;
         }

--- a/dbfit-java/core/src/main/java/dbfit/util/SymbolAccessSetBinding.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/SymbolAccessSetBinding.java
@@ -5,6 +5,7 @@ import fit.Fixture;
 import fit.Parse;
 
 import static dbfit.util.SymbolUtil.isSymbolGetter;
+import static dbfit.util.SymbolUtil.isSymbolHidden;
 
 public class SymbolAccessSetBinding extends Binding.SetBinding {
 
@@ -13,7 +14,9 @@ public class SymbolAccessSetBinding extends Binding.SetBinding {
         String text = cell.text();
         if (isSymbolGetter(text)) {
             Object value = dbfit.util.SymbolUtil.getSymbol(text);
-            cell.addToBody(Fixture.gray(" = " + String.valueOf(value)));
+            if (!isSymbolHidden(text)) {
+                cell.addToBody(Fixture.gray(" = " + String.valueOf(value)));
+            }
             adapter.set(value);
             return;
         }

--- a/dbfit-java/core/src/main/java/dbfit/util/SymbolReference.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/SymbolReference.java
@@ -1,11 +1,13 @@
 package dbfit.util;
 
+import static java.util.Arrays.asList;
+
 public class SymbolReference {
 
     private String name;
     private String prefix;
 
-    private static final String[] PREFIXES = { "<<", ">>" };
+    private static final String[] PREFIXES = { "<<<", ">>>", "<<", ">>" };
 
     public String getName() {
         return name;
@@ -21,6 +23,10 @@ public class SymbolReference {
 
     public boolean isSymbolSetter() {
         return getPrefix().startsWith(">>");
+    }
+
+    public boolean isHidden() {
+        return asList("<<<", ">>>").contains(getPrefix());
     }
 
     private SymbolReference(String name, String prefix) {

--- a/dbfit-java/core/src/main/java/dbfit/util/SymbolUtil.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/SymbolUtil.java
@@ -60,4 +60,8 @@ public class SymbolUtil {
     public static boolean isSymbolSetter(String text) {
         return SymbolReference.fromFullName(text).isSymbolSetter();
     }
+
+    public static boolean isSymbolHidden(String text) {
+        return SymbolReference.fromFullName(text).isHidden();
+    }
 }

--- a/dbfit-java/core/src/test/java/dbfit/util/SymbolReferenceTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/SymbolReferenceTest.java
@@ -47,4 +47,16 @@ public class SymbolReferenceTest {
             super("SYMBOL_X", ">>", ">>SYMBOL_X");
         }
     }
+
+    public static class HiddenSymbolGetterReferenceTest extends AbstractSymbolReferenceTest {
+        public HiddenSymbolGetterReferenceTest() {
+            super("SYMBOL_X", "<<<", "<<<SYMBOL_X");
+        }
+    }
+
+    public static class HiddenSymbolSetterReferenceTest extends AbstractSymbolReferenceTest {
+        public HiddenSymbolSetterReferenceTest() {
+            super("SYMBOL_X", ">>>", ">>>SYMBOL_X");
+        }
+    }
 }

--- a/dbfit-java/core/src/test/java/dbfit/util/SymbolUtilTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/SymbolUtilTest.java
@@ -3,6 +3,7 @@ package dbfit.util;
 import static dbfit.util.SymbolUtil.getSymbol;
 import static dbfit.util.SymbolUtil.isSymbolGetter;
 import static dbfit.util.SymbolUtil.isSymbolSetter;
+import static dbfit.util.SymbolUtil.isSymbolHidden;
 
 import org.junit.Test;
 import org.junit.Before;
@@ -47,23 +48,28 @@ public class SymbolUtilTest {
         private String symbolFullName;
         private boolean expectedIsSymbolGetter;
         private boolean expectedIsSymbolSetter;
+        private boolean expectedIsSymbolHidden;
 
         public IsSymbolGetterOrSetterTest(
                 String symbolFullName,
                 Boolean expectedIsSymbolGetter,
-                Boolean expectedIsSymbolSetter) {
+                Boolean expectedIsSymbolSetter,
+                Boolean expectedIsSymbolHidden) {
             this.symbolFullName = symbolFullName;
             this.expectedIsSymbolGetter = expectedIsSymbolGetter;
             this.expectedIsSymbolSetter = expectedIsSymbolSetter;
+            this.expectedIsSymbolHidden = expectedIsSymbolHidden;
         }
 
         @Parameters(name = "({index}): symbol {0} -> expecting {1}")
         public static Collection<Object[]> data() throws Exception {
             return java.util.Arrays.asList(new Object[][] {
-                {"<<SYMBOL_X", true,  false},
-                {">>SYMBOL_X", false, true},
-                {"SYMBOL_X",   false, false},
-                {null,         false, false}
+                {"<<SYMBOL_X",  true,  false, false},
+                {">>SYMBOL_X",  false, true,  false},
+                {"<<<SYMBOL_X", true,  false, true},
+                {">>>SYMBOL_X", false, true,  true},
+                {"SYMBOL_X",    false, false, false},
+                {null,          false, false, false}
             });
         }
 
@@ -75,6 +81,11 @@ public class SymbolUtilTest {
         @Test
         public void testIsSymbolSetter() {
             assertEquals(expectedIsSymbolSetter, isSymbolSetter(symbolFullName));
+        }
+
+        @Test
+        public void testIsSymbolHidden() {
+            assertEquals(expectedIsSymbolHidden, isSymbolHidden(symbolFullName));
         }
     }
 }

--- a/website/_includes/manual/working-with-parameters.md
+++ b/website/_includes/manual/working-with-parameters.md
@@ -1,6 +1,6 @@
 ## Working with parameters
 
-DbFit enables you to use Fixture symbols as global variables during test execution, to store or read intermediate results. The .NET syntax to access symbols (`>>parameter` to store a value and `<<parameter` to read the value) is supported in both .NET and Java versions. In addition, you can use the `Set Parameter` command to explicitly set a parameter value to a string.
+DbFit enables you to use Fixture symbols as global variables during test execution, to store or read intermediate results. The .NET syntax to access symbols (`>>parameter` to store a value and `<<parameter` to read the value) is supported in both .NET and Java versions. To suppress the output of the value you may use `>>>parameter` and `<<<parameter`. In addition, you can use the `Set Parameter` command to explicitly set a parameter value to a string.
 
     |Set parameter|username|arthur|
 


### PR DESCRIPTION
Add support for getting/setting symbols without displaying their values. This is achieved via the following syntax:
```
<<<symbol_name
>>>symbol_name
```

The functionality has been originally requested in the mailing list https://groups.google.com/d/msg/dbfit/q9R4wtJ9z8Y/IkVChUDIDwAJ

**TODO**
- [x] Update the reference documentation
- [x] Consider a common for all databases tests for stored procedures too. (Done but waiting for the HSQLDB stored procs support pull request)