### PR TITLE
Run travisbuild in --continue mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - for i in {1..60}; do echo "$i waiting for Oracle server startup"; nc -w2 -q1 localhost 49160 | grep SSH && echo "[Oracle UP]" && break || sleep 6; done
   - for i in {1..60}; do echo "$i waiting for DB2 server startup"; docker exec dbfitdb2 /scripts/detect_dbstart.sh 2 && break || sleep 6; done
   - docker exec dbfitdb2 /scripts/create_db_schema.sh
-script: "./gradlew clean travisbuild"
+script: "./gradlew --continue clean travisbuild"
 jdk:
 - oraclejdk7
 - oraclejdk8


### PR DESCRIPTION
Allow Travis CI to continue running in case of task failures. This helps getting broader feedback from the tests - e.g. don't stop running all integration tests when just one of them is failing.

https://docs.gradle.org/3.4.1/userguide/tutorial_gradle_command_line.html#sec:continue_build_on_failure