### PR TITLE
Symbol setter value parser support

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/CoreTests/CommonSuite/Symbols.wiki
+++ b/FitNesseRoot/DbFit/AcceptanceTests/CoreTests/CommonSuite/Symbols.wiki
@@ -42,9 +42,9 @@ Test
 
 !3 Set Parameter
 
-!|Set Parameter|x3|103|
+!|Set Parameter|x3|103|java.lang.Integer|
 
-!|Set Parameter|x4|104|
+!|Set Parameter|x4|104|java.lang.Integer|
 
 !|Set Parameter|v3|<<x3|
 

--- a/dbfit-java/core/src/main/java/dbfit/DatabaseTest.java
+++ b/dbfit-java/core/src/main/java/dbfit/DatabaseTest.java
@@ -63,6 +63,10 @@ public class DatabaseTest extends Fixture {
         dbfit.fixture.SetParameter.setParameter(name, value);
     }
 
+    public void setParameter(String name, String value, String parseDelegate) {
+        dbfit.fixture.SetParameter.setParameter(name, value, parseDelegate);
+    }
+
     public void clearParameters() {
         SymbolUtil.clearSymbols();
     }

--- a/dbfit-java/core/src/main/java/dbfit/fixture/SetParameter.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/SetParameter.java
@@ -16,9 +16,18 @@ public class SetParameter extends fit.Fixture {
         dbfit.util.SymbolUtil.setSymbol(name, parser.parse(value));
     }
 
+    public static void setParameter(String name, String value, String parseDelegate) {
+        dbfit.util.SymbolUtil.setSymbol(name, parser.parse(value, parseDelegate));
+    }
+
     @Override
     public void doTable(Parse table) {
-        if (args.length != 2) throw new UnsupportedOperationException("Set parameter requires two arguments");
-        setParameter(args[0], args[1]);
+        if (args.length == 2) {
+            setParameter(args[0], args[1]);
+        } else if (args.length == 3) {
+            setParameter(args[0], args[1], args[2]);
+        } else {
+            throw new UnsupportedOperationException("Set parameter requires two or three arguments");
+        }
     }
 }

--- a/dbfit-java/core/src/main/java/dbfit/util/ValueParser.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/ValueParser.java
@@ -1,5 +1,8 @@
 package dbfit.util;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
+
 public class ValueParser {
 
     public Object parse(String text) {
@@ -9,6 +12,30 @@ public class ValueParser {
             return SymbolUtil.getSymbol(text);
         } else {
             return text;
+        }
+    }
+
+    public Object parse(String text, Class<?> parseDelegateClass) {
+        try {
+            return findParsingMethod(parseDelegateClass).invoke(null, text);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public Object parse(String text, String parseDelegateClassName) {
+        try {
+            return parse(text, Class.forName(parseDelegateClassName));
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private Method findParsingMethod(Class<?> cls) throws NoSuchMethodException {
+        try {
+            return cls.getMethod("valueOf", String.class);
+        } catch (NoSuchMethodException e) {
+            return cls.getMethod("parse", String.class);
         }
     }
 }

--- a/dbfit-java/core/src/test/java/dbfit/util/ValueParserTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/ValueParserTest.java
@@ -1,5 +1,7 @@
 package dbfit.util;
 
+import java.math.BigDecimal;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -30,6 +32,23 @@ public class ValueParserTest {
     @Test
     public void canParseMixedCaseNullString() {
         assertEquals(null, parser.parse("NulL"));
+    }
+
+    @Test
+    public void canParseWithParseDelegateClass() {
+        NormalisedBigDecimal expected = new NormalisedBigDecimal(new BigDecimal(123));
+        assertEquals(expected, parser.parse("123", BigDecimalParseDelegate.class));
+    }
+
+    @Test
+    public void canParseWithParseDelegateClassName() {
+        NormalisedBigDecimal expected = new NormalisedBigDecimal(new BigDecimal(123));
+        assertEquals(expected, parser.parse("123", "dbfit.util.BigDecimalParseDelegate"));
+    }
+
+    @Test
+    public void canParseUsingDelgateWithValueOfMethod() {
+        assertEquals(Integer.valueOf(7), parser.parse("7", "java.lang.Integer"));
     }
 
     @Test

--- a/website/_includes/manual/working-with-parameters.md
+++ b/website/_includes/manual/working-with-parameters.md
@@ -4,6 +4,10 @@ DbFit enables you to use Fixture symbols as global variables during test executi
 
     |Set parameter|username|arthur|
 
-DbFit is type sensitive, which means that comparing strings to numbers, even if both have the value 11, will fail the test. Most databases will allow you to pass strings into numeric arguments, but if you get an error that a value is different than expected and it looks the same, it is most likely due to a wrong type conversion. Keep that in mind when using `Set parameter`. A good practice to avoid type problems is to read out parameter values from a query. This will be explained in detail soon.
+DbFit is type sensitive, which means that comparing strings to numbers, even if both have the value 11, will fail the test. Most databases will allow you to pass strings into numeric arguments, but if you get an error that a value is different than expected and it looks the same, it is most likely due to a wrong type conversion. Keep that in mind when using `Set parameter`. A good practice to avoid type problems is to read out parameter values from a query. This will be explained in detail soon. Another way to solve that problem is to specify a custom parser:
+
+    |Set parameter|partscount|7|java.lang.Integer|
+
+The last parameter, `java.lang.Integer` in the above example, is expected to be class name with a `static` method `Object valueOf(String)` or `Object parse(String)`. DbFit will use it to convert the given text to a Java object, and that object will be set as the parameter value.
 
 You can also use the keyword `NULL` to set a parameter value to `NULL`.


### PR DESCRIPTION
Add support for specifying value parser class in `SetParameter` fixture. This allows setting non-String parameters. Partially addresses #557.

TODO:
- [x] Update the documentation - describe the new feature and remove notes that "only string" can be set.
- [x] Consider slicing the ValueParser refactoring to separate PR