### PR TITLE
Informix CalcLength: rename 1st arg to unify the definition

### DIFF
--- a/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/InformixTests/LibraryTests/CommonTests/StoredProcedures/content.txt
+++ b/FitNesseRoot/DbFit/AcceptanceTests/JavaTests/InformixTests/LibraryTests/CommonTests/StoredProcedures/content.txt
@@ -1,7 +1,7 @@
 !3 IN and OUT params
 
 !|Execute Procedure|CalcLength|
-|In String|Str Length?|
+|Name|Str Length?|
 |mika|4|
 |paradajz|8|
 |saeiluhrweurhfi7fhi7rhgf|24|

--- a/dbfit-java/informix/src/integration-test/resources/create-acceptance-test-objects-informix.sql
+++ b/dbfit-java/informix/src/integration-test/resources/create-acceptance-test-objects-informix.sql
@@ -4,7 +4,7 @@ CREATE FUNCTION ConcatenateF(FirstString VARCHAR(100), SecondString VARCHAR(100)
 
 CREATE FUNCTION FuncWithOutParams(InString VARCHAR(100), OUT OutString VARCHAR(200)) RETURNS VARCHAR(200) LET OutString = InString || ' returned via OUT param'; RETURN InString || ' returned via RETURNS'; END FUNCTION;
 
-CREATE PROCEDURE CalcLength(InString VARCHAR(255), OUT StrLength INTEGER) LET StrLength = LENGTH(InString); RETURN; END PROCEDURE;
+CREATE PROCEDURE CalcLength(Name VARCHAR(255), OUT StrLength INTEGER) LET StrLength = LENGTH(Name); RETURN; END PROCEDURE;
 
 CREATE PROCEDURE ConcatenateStrings(FirstString VARCHAR(255), SecondString VARCHAR(255), OUT Concatenated VARCHAR(255)) LET Concatenated = FirstString || ' ' || SecondString; RETURN; END PROCEDURE;
 


### PR DESCRIPTION
Rename CalcLength 1st argument to Name in order to have the same definition across all databases. This fixes common Symbols test relying on CalcLength.