### PR TITLE
Include SQL Server integration tests in Gradle tasks

### DIFF
--- a/test_vm/vendor/cookbooks/dbfit_test/recipes/gradle.rb
+++ b/test_vm/vendor/cookbooks/dbfit_test/recipes/gradle.rb
@@ -1,7 +1,7 @@
 project_root = node['dbfit']['project_root']
   
 file "#{project_root}/gradle.properties" do
-  content "excludeIntegrationTests=netezza,sqlserver,teradata\n"
+  content "excludeIntegrationTests=netezza,teradata\n"
   mode '0644'
   owner 'vagrant'
   group 'vagrant'


### PR DESCRIPTION
Include SQL Server integration tests in Gradle `integrationBuild` task not SQL Server is provisioned on the dev/test VM. 