### PR TITLE
Correct paths to Informix connection properties files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,9 @@ build
 gradle.properties
 target
 dbfit-complete-*.zip
-dbfit-java/oracle/TestDbConnectionDbFitInformixINFORMIX.properties
-dbfit-java/oracle/TestDbConnectionDbFitInformixINFORMIX.properties.custom
-dbfit-java/oracle/TestDbConnectionDbFitInformixANSI.properties
-dbfit-java/oracle/TestDbConnectionDbFitInformixANSI.properties.custom
+dbfit-java/informix/TestDbConnectionDbFitInformixINFORMIX.properties
+dbfit-java/informix/TestDbConnectionDbFitInformixINFORMIX.properties.custom
+dbfit-java/informix/TestDbConnectionDbFitInformixANSI.properties
+dbfit-java/informix/TestDbConnectionDbFitInformixANSI.properties.custom
 dbfit-java/oracle/TestDbConnectionDbFitOracle.properties
 dbfit-java/oracle/TestDbConnectionDbFitOracle.properties.custom


### PR DESCRIPTION
Correct the path names of Informix connection properties files in `.gitignore`.