### PR TITLE
Correct Netezza test DB setup/teardown

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -346,7 +346,7 @@ project('netezza') {
             connectionProperties.userName,
             connectionProperties.passWord,
             scriptFile,
-            connectionProperties.delimiterType, true)
+            connectionProperties.delimiterType, ';', true)
     }
 
     task setUpTestDatabase(dependsOn: connectionProperties) {


### PR DESCRIPTION
The Netezza test DB statements we being submitted as a single request because of the missing statement delimiter (the autocommit option was being used for the delimiter).