### PR TITLE
Gradle wrapper - use http instead of https

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - docker exec dbfitdb2 /scripts/create_db_schema.sh
 script: "./gradlew --continue clean travisbuild"
 jdk:
-- oraclejdk7
+- openjdk7
 - oraclejdk8
 after_success:
 - "./gradlew bundle"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-4.0-bin.zip


### PR DESCRIPTION
There is a problem with java 7 when using https so here we workaround it by tweaking the gradle download url.

resolves #592 