### PR TITLE
Fix Eclipse plugin library resolution errors

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -31,13 +31,6 @@ allprojects {
         }
     }
 
-    dependencies {
-        compile "org.fitnesse:fitnesse:${fitNesseVersion}:standalone@jar"
-    }
-}
-
-subprojects {
-    jar.baseName = "dbfit-" + project.archivesBaseName
     repositories {
         flatDir {
             dirs "${rootProject.projectDir}/custom_libs"
@@ -51,6 +44,14 @@ subprojects {
             ivyPattern "https://aws.amazon.com/s3/ivy.xml"
         }
     }
+
+    dependencies {
+        compile "org.fitnesse:fitnesse:${fitNesseVersion}:standalone@jar"
+    }
+}
+
+subprojects {
+    jar.baseName = "dbfit-" + project.archivesBaseName
 
     task libs(type: Copy) {
         from configurations.runtime


### PR DESCRIPTION
Ensure dependencies from top-level project can be resolved in current Gradle version when using Eclipse plugin.