### PR TITLE
improve Connecting to the DB instructions

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -86,9 +86,9 @@ DbFit requires two commands to connect to the database. The first line specifies
 
     !|dbfit.MySqlTest|
 
-    !|Connect|localhost|dbfit_user|password|dbfit|
+    !|Connect|localhost|dbfit_user|password|testdb|
 
-Notice the `MySqlTest` in the first line above. That tells DbFit which type of database driver to use.
+Notice the `MySqlTest` in the first line above. That tells DbFit which type of database driver to use. Check [Database-specific Information](/dbfit/docs/database-specific-information.html) for additional steps required to connect to some databases.
 
 Here's a comprehensive list of available types:
 


### PR DESCRIPTION
I tried following the [Getting started documentation](http://dbfit.github.io/dbfit/docs/getting-started.html) using MS SQL Server. It implied I could just change "MySqlTest" with "SqlServerTest" and get running, but it isn't the case: one has to install the JDBC driver.

Luckily this is already described in DB-specific instructions and in the FAQ, but I didn't think to look there before getting started -- so I think adding a link would be beneficial.

Another thing that go me confused was the `Connect` string: from the `dbfit_user|password|dbfit` example I assumed that  "dbfit" was the password (and the "password" was a weird marker). I changed it to `dbfit_user|password|testdb` so that it's clear what the last parameter is.