### PR TITLE
Prerequisite changes to Core for Sybase support

### DIFF
--- a/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
+++ b/dbfit-java/core/src/main/java/dbfit/api/AbstractDbEnvironment.java
@@ -106,6 +106,11 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
         return commandText;
     }
 
+    protected void bindStatementParameter(PreparedStatement statement,
+            int parameterIndex, Object value) throws SQLException {
+        statement.setObject(parameterIndex, value);
+    }
+
     public final PreparedStatement createStatementWithBoundFixtureSymbols(
             TestHost testHost, String commandText) throws SQLException {
         String command = Options.isBindSymbols() ? parseCommandText(commandText) : commandText;
@@ -116,7 +121,7 @@ public abstract class AbstractDbEnvironment implements DBEnvironment {
             String paramNames[] = extractParamNames(commandText);
             for (int i = 0; i < paramNames.length; i++) {
                 Object value = testHost.getSymbolValue(paramNames[i]);
-                cs.setObject(i + 1, value);
+                bindStatementParameter(cs, i + 1, value);
             }
         }
         return cs;

--- a/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
+++ b/dbfit-java/core/src/main/java/dbfit/fixture/StatementExecution.java
@@ -19,7 +19,11 @@ public class StatementExecution implements AutoCloseable {
 
     public void setObject(int index, Object value, int sqlType, String userDefinedTypeName) throws SQLException {
         if (value == null) {
-            statement.setNull(index, sqlType, userDefinedTypeName);
+            if (userDefinedTypeName == null) {
+                statement.setNull(index, sqlType);
+            } else {
+                statement.setNull(index, sqlType, userDefinedTypeName);
+            }
         } else {
             // Don't use the variant that takes sqlType.
             // Derby (at least) assumes no decimal places for Types.DECIMAL and truncates the source data.

--- a/dbfit-java/core/src/main/java/dbfit/util/DataColumn.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/DataColumn.java
@@ -22,6 +22,9 @@ public class DataColumn {
         this.name = r.getColumnLabel(columnIndex);
         this.javaClassName = r.getColumnClassName(columnIndex);
         this.dbTypeName = r.getColumnTypeName(columnIndex);
+        if (this.dbTypeName == null) {
+            this.dbTypeName = JdbcTypeNames.getTypeName(r.getColumnType(columnIndex));
+        }
     }
 
     public String getDbTypeName() {

--- a/dbfit-java/core/src/main/java/dbfit/util/JdbcTypeNames.java
+++ b/dbfit-java/core/src/main/java/dbfit/util/JdbcTypeNames.java
@@ -1,0 +1,24 @@
+package dbfit.util;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.sql.Types;
+
+public class JdbcTypeNames {
+    private static Map<Integer, String> typeNames = new HashMap<Integer, String>();
+
+    static {
+        for (Field field : Types.class.getFields()) {
+            try {
+                typeNames.put((Integer)field.get(null), field.getName());
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public static String getTypeName(int typeNumber) {
+        return typeNames.get(typeNumber);
+    }
+}


### PR DESCRIPTION
Preparation for Sybase IQ support and for other drivers that might have incomplete JDBC implementations.
* Use JDBC type when driver ResultSetMetaData does not provide the DB type for a column.
* Call appropriate setNull when no user defined type name.
* Allow setObject behaviours to be specified for a specific DB type.

