### PR TITLE
Bump up releasing/Gemfile.lock - fixes security warnings

### DIFF
--- a/releasing/Gemfile.lock
+++ b/releasing/Gemfile.lock
@@ -1,59 +1,51 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.8)
-    backports (3.6.6)
-    coderay (1.1.0)
-    ethon (0.7.4)
+    addressable (2.4.0)
+    backports (3.17.0)
+    ethon (0.12.0)
       ffi (>= 1.3.0)
-    faraday (0.9.1)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
-    ffi (1.9.10)
-    gh (0.14.0)
-      addressable
+    faraday_middleware (0.14.0)
+      faraday (>= 0.7.4, < 1.0)
+    ffi (1.12.2)
+    gh (0.15.1)
+      addressable (~> 2.4.0)
       backports
       faraday (~> 0.8)
       multi_json (~> 1.0)
-      net-http-persistent (>= 2.7)
+      net-http-persistent (~> 2.9)
       net-http-pipeline
-    highline (1.7.3)
-    json (1.8.3)
+    highline (1.7.10)
+    json (2.3.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    method_source (0.8.2)
-    multi_json (1.11.2)
-    multipart-post (2.0.0)
+    multi_json (1.14.1)
+    multipart-post (2.1.1)
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
-    octokit (4.0.1)
-      sawyer (~> 0.6.0, >= 0.5.3)
-    pry (0.9.12.6)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
-      slop (~> 3.4)
+    octokit (4.17.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
-    sawyer (0.6.0)
-      addressable (~> 2.3.5)
-      faraday (~> 0.8, < 0.10)
-    slop (3.6.0)
-    travis (1.8.0)
-      addressable (~> 2.3)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
+    travis (1.8.11)
       backports
       faraday (~> 0.9)
       faraday_middleware (~> 0.9, >= 0.9.1)
       gh (~> 0.13)
       highline (~> 1.6)
       launchy (~> 2.1)
-      pry (~> 0.9, < 0.10)
       pusher-client (~> 0.4)
       typhoeus (~> 0.6, >= 0.6.8)
-    typhoeus (0.7.3)
-      ethon (>= 0.7.4)
-    websocket (1.2.2)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    websocket (1.2.8)
 
 PLATFORMS
   ruby
@@ -63,4 +55,4 @@ DEPENDENCIES
   travis
 
 BUNDLED WITH
-   1.10.5
+   2.1.4


### PR DESCRIPTION
* This resolves #643 - a security alert regarding ffi (CVE-2018-1000201)
  in releasing scripts' dependencies. (Not something affecting dbfit
  product itself)
* Other dependencies are also updated