### PR TITLE
Configure S3 repo to be gradle 6.x compatible

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -42,6 +42,10 @@ allprojects {
         ivy {
             artifactPattern "https://s3.amazonaws.com/dbfit/[artifact]-[revision].[ext]"
             ivyPattern "https://aws.amazon.com/s3/ivy.xml"
+            metadataSources {
+                ivyDescriptor()
+                artifact()
+            }
         }
     }
 


### PR DESCRIPTION
Configure S3 repo to be gradle 6.x compatible

Gradle 6.x has different defaults for ivy repos. This change allows using dependencies from Amazon S3.

https://github.com/gradle/gradle/issues/10850