### PR TITLE
Ignore vscode config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dbfit-java/derby/dbfit/
 .project
 .classpath
 out
+.vscode
 
 dist
 /zips/


### PR DESCRIPTION
Let Git ignore VisualStudio code config file to facilitate using this IDE

Cherry-picked by contribution of @bhuesemann