### PR TITLE
Bump up to jdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ script:
   - ./gradlew --continue clean travisbuild
   - ./gradlew bundle
 jdk:
-- openjdk7
-- oraclejdk8
+  - openjdk8
+  - oraclejdk8
 addons:
   artifacts:
     paths:

--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -15,6 +15,9 @@ allprojects {
     group = 'com.github.dbfit'
     version = rootProject.dbfitVersion
 
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+
     checkstyle {
         configFile = new File(parent.projectDir, "config/checkstyle/checkstyle.xml")
     }

--- a/dbfit-java/oracle/src/main/java/dbfit/environment/OracleClobNormaliser.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/environment/OracleClobNormaliser.java
@@ -12,17 +12,14 @@ public class OracleClobNormaliser implements TypeTransformer {
     public Object transform(Object o) throws SQLException {
         if (o == null)
             return null;
-        if (!(o instanceof oracle.sql.CLOB)) {
-            throw new UnsupportedOperationException(
-                    "OracleClobNormaliser cannot work with " + o.getClass());
+        if (!(o instanceof java.sql.Clob)) {
+            throw new UnsupportedOperationException("OracleClobNormaliser cannot work with " + o.getClass());
         }
-        oracle.sql.CLOB clob = (oracle.sql.CLOB) o;
+        java.sql.Clob clob = (java.sql.Clob) o;
         if (clob.length() > MAX_CLOB_LENGTH)
-            throw new UnsupportedOperationException("Clobs larger than "
-                    + MAX_CLOB_LENGTH + " bytes are not supported by DBFIT");
-        char[] buffer = new char[MAX_CLOB_LENGTH];
-        int total = clob.getChars(1, MAX_CLOB_LENGTH, buffer);
-        return String.valueOf(buffer, 0, total);
+            throw new UnsupportedOperationException(
+                    "Clobs larger than " + MAX_CLOB_LENGTH + " bytes are not supported by DBFIT");
+        return clob.getSubString(1, MAX_CLOB_LENGTH);
     }
 
 }

--- a/dbfit-java/oracle/src/test/java/dbfit/environment/OracleClobNormaliserTest.java
+++ b/dbfit-java/oracle/src/test/java/dbfit/environment/OracleClobNormaliserTest.java
@@ -3,12 +3,11 @@ package dbfit.environment;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 
 import java.sql.SQLException;
 
-import oracle.sql.CLOB;
+import java.sql.Clob;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,7 +32,7 @@ public class OracleClobNormaliserTest {
 
     @Test
     public void shouldThrowCorrectExceptionIfClobIsLargerThanMaximum() throws SQLException {
-        CLOB clob = mock(CLOB.class);
+        Clob clob = mock(Clob.class);
 
         when(clob.length()).thenReturn(10001l);
         expectedEx.expect(UnsupportedOperationException.class);
@@ -44,13 +43,13 @@ public class OracleClobNormaliserTest {
 
     @Test
     public void shouldReturnContentsOfClobIFAllOkay() throws SQLException {
-        CLOB clob = mock(CLOB.class);
+        Clob clob = mock(Clob.class);
 
         when(clob.length()).thenReturn(Long.valueOf("CLOB contents".length()));
-        when(clob.getChars(eq(1l), eq(10000), any(char[].class))).thenReturn("CLOB contents".length());
+        when(clob.getSubString(eq(1l), eq(10000))).thenReturn("CLOB contents");
 
         // can't do this as we don't fill up the passed buffer
-        //assertEquals("CLOB contents", new OracleClobNormaliser().normalise(clob));
+        // assertEquals("CLOB contents", new OracleClobNormaliser().normalise(clob));
         new OracleClobNormaliser().transform(clob);
     }
 }

--- a/releasing/fetch_last_successful_artefact
+++ b/releasing/fetch_last_successful_artefact
@@ -5,17 +5,17 @@ require 'travis'
 S3_BASE_URL = "https://s3.amazonaws.com/dbfit"
 
 def artefact_url_from_last_successful_job
-  job = last_successful_jdk7_job
+  job = last_successful_jdk8_job
   relative_url = job.log.colorized_body.scan(/Uploading file .*? to (.*?), public: true/).flatten.first
   commit = job.commit
   { url: "#{S3_BASE_URL}/#{relative_url}", commit_message: "#{commit.author_name} - #{commit.subject}" }
 end
 
-def last_successful_jdk7_job
+def last_successful_jdk8_job
   repo = Travis::Repository.find('dbfit/dbfit')
   last_successful_build = repo.builds.detect(&:passed?)
   last_successful_build.jobs.inspect # workaround for lazy loading, so that the next line works
-  last_successful_build.jobs.detect { |job| job.attributes["config"]["jdk"] == "oraclejdk7" }
+  last_successful_build.jobs.detect { |job| job.attributes["config"]["jdk"] == "oraclejdk8" }
 end
 
 artefact = artefact_url_from_last_successful_job


### PR DESCRIPTION
This is the essensce of PR #654 by @bhuesemann. Other stuff not coupled with JDK8 bump up will be delivered with other PRs.

Here we bump up Java source and runtime compatibility level to Java 8. Java 7 is not supported anymore.