### PR TITLE
fix bin folder location in gradle eclipse generation of .classpath files

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -55,6 +55,25 @@ allprojects {
     dependencies {
         compile "org.fitnesse:fitnesse:${fitNesseVersion}:standalone@jar"
     }
+    
+    // fix gradle .classpath generation for bin folders and put it under /build/eclipse
+	eclipse {
+		classpath {
+            defaultOutputDir = file('build/eclipse') // this should be enough, but it's not
+		    file.whenMerged {
+			   entries.each { entry ->
+					if (entry instanceof org.gradle.plugins.ide.eclipse.model.Output) {
+					   entry.path = entry.path.replace('bin/main', 'build/eclipse/main')
+					}
+					if (entry instanceof org.gradle.plugins.ide.eclipse.model.SourceFolder) {
+					   entry.output = entry.output.replace('bin/main', 'build/eclipse/main')
+                       entry.output = entry.output.replace('bin/test', 'build/eclipse/test')
+                       entry.output = entry.output.replace('bin/integrationTest', 'build/eclipse/integrationTest')
+					}
+			   }
+		   }
+		}
+	}     
 }
 
 subprojects {

--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -57,23 +57,22 @@ allprojects {
     }
     
     // fix gradle .classpath generation for bin folders and put it under /build/eclipse
-	eclipse {
-		classpath {
+    eclipse {
+        classpath {
             defaultOutputDir = file('build/eclipse') // this should be enough, but it's not
-		    file.whenMerged {
-			   entries.each { entry ->
-					if (entry instanceof org.gradle.plugins.ide.eclipse.model.Output) {
-					   entry.path = entry.path.replace('bin/main', 'build/eclipse/main')
-					}
-					if (entry instanceof org.gradle.plugins.ide.eclipse.model.SourceFolder) {
-					   entry.output = entry.output.replace('bin/main', 'build/eclipse/main')
-                       entry.output = entry.output.replace('bin/test', 'build/eclipse/test')
-                       entry.output = entry.output.replace('bin/integrationTest', 'build/eclipse/integrationTest')
-					}
-			   }
-		   }
-		}
-	}     
+            file.whenMerged {
+                entries.each { entry ->
+                    if (entry instanceof org.gradle.plugins.ide.eclipse.model.Output) {
+                        entry.path = entry.path.replaceFirst('^bin', 'build/eclipse')
+                    }
+
+                    if (entry instanceof org.gradle.plugins.ide.eclipse.model.SourceFolder) {
+                        entry.output = entry.output.replaceFirst('^bin', 'build/eclipse')
+                    }
+                }
+            }
+        }
+    }
 }
 
 subprojects {


### PR DESCRIPTION
Eclipse and VSC IDE integration is supported by gradle by using the command
gradle clean cleanEclipse assemble eclipse

It will generate the .project and .classpath files needed by the IDEs and their internal Java tooling. However, the generated default compile directory might interfere with bin directories of the project and should be put under the gradle build folder in a separate folder. 

This PR will tweak gradle to put the move and rename the bin directories under:
<root>/dbfit-java/<subproject>/build/eclipse
instead of 
<root>/dbfit-java/<subproject>/bin