### PR TITLE
Bump up oracle JDBC to 19.3

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -344,7 +344,7 @@ project('oracle') {
 
     dependencies {
         compile project(':dbfit-java:core')
-        compile 'dummy:ojdbc6:11.2.0.3.0@jar'
+        compile 'com.oracle.ojdbc:ojdbc8:19.3.0.0'
         compile publicOracleCompileDeps
         testCompile "org.mockito:mockito-core:${mockitoVersion}"
     }

--- a/dbfit-java/oracle/redeploy-odjbc.bat
+++ b/dbfit-java/oracle/redeploy-odjbc.bat
@@ -1,1 +1,0 @@
-mvn install:install-file -Dfile=ojdbc6.jar -DgroupId=com.oracle -DartifactId=ojdbc6 -Dversion=11.2.0.3.0 -Dpackaging=jar

--- a/dbfit-java/oracle/src/main/java/dbfit/environment/OracleEnvironment.java
+++ b/dbfit-java/oracle/src/main/java/dbfit/environment/OracleEnvironment.java
@@ -222,7 +222,7 @@ public class OracleEnvironment extends AbstractDbEnvironment {
                 new OracleTimestampNormaliser());
         TypeNormaliserFactory.setNormaliser(oracle.sql.DATE.class,
                 new OracleDateNormaliser());
-        TypeNormaliserFactory.setNormaliser(oracle.sql.CLOB.class,
+        TypeNormaliserFactory.setNormaliser(oracle.jdbc.OracleClob.class,
                 new OracleClobNormaliser());
         TypeNormaliserFactory.setNormaliser(oracle.jdbc.rowset.OracleSerialClob.class,
                 new OracleSerialClobNormaliser());


### PR DESCRIPTION
Add support for Oracle 12+ and bump up ojdbc dependency to 19.3

Related to #666, #672
Resolves #672