### PR TITLE
Fix BigDecimalParseDelegate test (normalise -> transform)

### DIFF
--- a/dbfit-java/core/src/test/java/dbfit/util/BigDecimalParseDelegateLocaleTest.java
+++ b/dbfit-java/core/src/test/java/dbfit/util/BigDecimalParseDelegateLocaleTest.java
@@ -34,11 +34,11 @@ public class BigDecimalParseDelegateLocaleTest {
     }
 
     private BigDecimal normalise(BigDecimal val) {
-        return (BigDecimal) normaliser.normalise(val);
+        return (BigDecimal) normaliser.transform(val);
     }
 
     private BigDecimal normalise(Object val) {
-        return (BigDecimal) normaliser.normalise(val);
+        return (BigDecimal) normaliser.transform(val);
     }
 
 }


### PR DESCRIPTION
Merged old PR didn't know about changed normalising API which is now
using *transform* instead of *normalise*.