### PR TITLE
Bump up FitNesse to v20211006

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    fitNesseVersion = '20180127'
+    fitNesseVersion = '20211006'
     mockitoVersion = '2.2.2'
     junitVersion = '4.12'
 }


### PR DESCRIPTION
Bump up FitNesse version to 20211006.

Note this this has been tested only with `gradlew fastbuild`.