### PR TITLE
Migrate deps from AWS S3 to github

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -43,8 +43,7 @@ allprojects {
             url "http://mvnrepository.com"
         }
         ivy {
-            artifactPattern "https://s3.amazonaws.com/dbfit/[artifact]-[revision].[ext]"
-            ivyPattern "https://aws.amazon.com/s3/ivy.xml"
+            artifactPattern "https://raw.githubusercontent.com/dbfit/dbfit-dependencies/main/[artifact]-[revision].[ext]"
             metadataSources {
                 ivyDescriptor()
                 artifact()


### PR DESCRIPTION
Migrate binary dependencies from Amazon S3 to github

This is for the build dependencies only. S3 is still in use for the artefacts (Travis CI build) - to be handled separately

Resolves a part of #683