### PR TITLE
Bump postgresql JDBC driver to 42.3.1

### DIFF
--- a/dbfit-java/build.gradle
+++ b/dbfit-java/build.gradle
@@ -370,7 +370,7 @@ project('mysql') {
 }
 
 def publicPostgresCompileDeps = [
-    'org.postgresql:postgresql:42.0.0.jre7'
+    'org.postgresql:postgresql:42.3.1'
 ]
 
 project('postgres') {


### PR DESCRIPTION
Newer versions of PostgreSQL server are raising an error
that "auth type 10 is not supported". Updating the JDBC driver resolves
this issue.

Reference - we got the following error on Github Actions with the old
driver:

    Task :dbfit-java:postgres:integrationTest FAILED
    [ant:dbdeploy] dbdeploy 3.0M3
    org.postgresql.util.PSQLException: The authentication type 10 is not supported.
    Check that you have configured the pg_hba.conf file to include the client's IP
    address or subnet, and that it is using an authentication scheme supported by
    the driver.