### PR TITLE
Use gradle action instead of gradle shell command

### DIFF
--- a/.github/actions/db-integration-test/action.yml
+++ b/.github/actions/db-integration-test/action.yml
@@ -29,8 +29,11 @@ runs:
     run: docker exec -w /tmp/dbfit_setup ${{ inputs.database_kind }} /bin/bash -i ./create_db_schema.sh
 
   - name: ${{ inputs.database_kind }} integration tests
-    shell: bash
-    run: ./gradlew fastbuild :dbfit-java:${{ inputs.database_kind }}:integrationTest
+    uses: gradle/gradle-build-action@v2
+    with:
+      arguments: |
+        fastbuild
+        :dbfit-java:${{ inputs.database_kind }}:integrationTest
 
   - name: Collect logs after
     shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,10 +148,16 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Fast build
-        run: ./gradlew clean fastbuild
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            clean
+            fastbuild
 
       - name: Bundle
-        run: ./gradlew bundle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: bundle
 
       - name: Determine bundle name
         run: echo "project_bundle=`basename zips/*.zip`" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,40 @@ on:
     - cron: "15 5 * * *"
 jobs:
 
+  fast-build:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest' ]
+        distribution: [ 'zulu' ]
+        java: [ '8' ]
+    runs-on: ${{ matrix.os }}
+    name: Java ${{ matrix.Java }} (${{ matrix.distribution }}) fastbuild
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fast build
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            clean
+            fastbuild
+
+      - name: Bundle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: bundle
+
+      - name: Determine bundle name
+        run: echo "project_bundle=`basename zips/*.zip`" >> $GITHUB_ENV
+
+      - name: Upload zips artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.project_bundle }}
+          path: ${{ github.workspace }}/zips/${{ env.project_bundle}}
+
   test_postgres:
     runs-on: ubuntu-20.04
     strategy:
@@ -134,36 +168,3 @@ jobs:
         uses: ./.github/actions/db-integration-test
         with:
           database_kind: oracle
-
-  build:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        distribution: [ 'zulu' ]
-        java: [ '8', '11' ]
-    name: Java ${{ matrix.Java }} (${{ matrix.distribution }}) fastbuild
-
-    steps:
-      - name: Fast build
-        uses: actions/checkout@v2
-
-      - name: Fast build
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: |
-            clean
-            fastbuild
-
-      - name: Bundle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: bundle
-
-      - name: Determine bundle name
-        run: echo "project_bundle=`basename zips/*.zip`" >> $GITHUB_ENV
-
-      - name: Upload zips artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.project_bundle }}
-          path: ${{ github.workspace }}/zips/${{ env.project_bundle}}


### PR DESCRIPTION
* Use gradle-buildaction for the gradle builds https://github.com/gradle/gradle-build-action
* Rearrange fastbuild task so that it's simpler (just one java version) - so that upload artifacts has higher chance not to fail