### PR TITLE
Add sqlserver to CI (github actions)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,3 +168,41 @@ jobs:
         uses: ./.github/actions/db-integration-test
         with:
           database_kind: oracle
+
+  test_sqlserver:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-20.04' ]
+        distribution: [ 'zulu' ]
+        java: [ '8' ]
+        db_kind: [ 'sqlserver' ]
+    runs-on: ${{ matrix.os }}
+    name: Java ${{ matrix.Java }} (${{ matrix.distribution }}) ${{ matrix.db_kind }}
+    env:
+      DB_ADMIN_PASSWORD: yourStrongP@ssword
+
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: ${{ env.DB_ADMIN_PASSWORD }}
+          MSSQL_PID: Express
+        ports:
+          - 1433:1433
+        options: >-
+          --name ${{ matrix.db_kind }}
+          --health-cmd "/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD -Q 'select 1' -b -o /dev/null"
+          --health-interval 60s
+          --health-timeout 30s
+          --health-start-period 20s
+          --health-retries 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Db Integration tests
+        uses: ./.github/actions/db-integration-test
+        with:
+          database_kind: ${{ matrix.db_kind }}

--- a/test_vm/scripts/sqlserver/create_db_schema.sh
+++ b/test_vm/scripts/sqlserver/create_db_schema.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -ev
+env
+
+THIS_DIR="`dirname $0`" && cd "${THIS_DIR}" && THIS_DIR="`pwd`" || { "Can't change to ${THIS_DIR}!"; exit 1; }
+
+sql_dir="./sql"
+sql_cmd="/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD}"
+
+${sql_cmd} -i ${sql_dir}/create-databases-sqlserver.sql
+${sql_cmd} -i ${sql_dir}/create-dbdeploy-changelog-sqlserver.sql


### PR DESCRIPTION
Setup SQL Server dbfit integration tests in Github Actions. Only run it Java 8 (unlike other integration tests) - as it might be taking more time to create all these containers and behavior on Java 8 vs Java 11 is not that different for now.