### PR TITLE
Add ability to manually run build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: build
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: "15 5 * * *"
 jobs:


### PR DESCRIPTION
Add ability to Github Actions build workflow for running on
workflow_dispatch (i.e. manually)