### PR TITLE
Fitnesse standalone jar selection refinement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ task wikiDocs(dependsOn: [wikiDocsUpdateList]) {
 }
 
 def fitnesseJar() {
-    fileTree(dir: 'dist/lib', include: 'fitnesse-*.jar').getSingleFile()
+    fileTree(dir: 'dist/lib', include: 'fitnesse-*standalone.jar').getSingleFile()
 }
 
 def flattenPath(def path) {


### PR DESCRIPTION
This has been suggested in PR #608 in order to be more consistent in
case of having other fitnesse jars for some reason.